### PR TITLE
Add all named endpoints and types

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -4,8 +4,17 @@ import { Logger, LogLevel, logLevelSeverity, makeConsoleLogger } from './logging
 import { buildRequestError, HTTPResponseError } from './errors'
 import { pick } from './helpers';
 import {
-  DatabasesRetrieveParameters, DatabasesRetrieveResponse, databasesRetrieve,
+  BlocksChildrenAppendParameters, BlocksChildrenAppendResponse, blocksChildrenAppend,
+  BlocksChildrenListParameters, BlocksChildrenListResponse, blocksChildrenList,
+  DatabasesListParameters, DatabasesListResponse, databasesList,
   DatabasesQueryResponse, DatabasesQueryParameters, databasesQuery,
+  DatabasesRetrieveParameters, DatabasesRetrieveResponse, databasesRetrieve,
+  PagesCreateParameters, PagesCreateResponse, pagesCreate,
+  PagesRetrieveParameters, PagesRetrieveResponse, pagesRetrieve,
+  PagesUpdateParameters, PagesUpdateResponse, pagesUpdate,
+  UsersListParameters, UsersListResponse, usersList,
+  UsersRetrieveParameters, UsersRetrieveResponse, usersRetrieve,
+  SearchParameters, SearchResponse, search,
 } from './api-endpoints';
 
 import got, { Got, Options as GotOptions, Headers as GotHeaders, Agents as GotAgents } from 'got';
@@ -52,7 +61,7 @@ export default class Client {
       headers: {
         'Notion-Version': notionVersion,
         // TODO: update with format appropriate for telemetry, use version from package.json
-        'user-agent': 'notion:client/v0.1.0',
+        'user-agent': 'notionhq-client/0.1.0',
       },
       retry: 0,
       agent: makeAgentOption(prefixUrl, options?.agent),
@@ -106,7 +115,50 @@ export default class Client {
    * Notion API endpoints
    */
 
+  public readonly blocks = {
+    children: {
+      /**
+       * Append block children
+       */
+      append: (args: WithAuth<BlocksChildrenAppendParameters>): Promise<BlocksChildrenAppendResponse> => {
+        return this.request<BlocksChildrenAppendResponse>({
+          path: blocksChildrenAppend.path(args),
+          method: blocksChildrenAppend.method,
+          query: pick(args, blocksChildrenAppend.queryParams),
+          body: pick(args, blocksChildrenAppend.bodyParams),
+          auth: args.auth,
+        });
+      },
+
+      /**
+       * Retrieve block children
+       */
+      list: (args: WithAuth<BlocksChildrenListParameters>): Promise<BlocksChildrenListResponse> => {
+        return this.request<BlocksChildrenListResponse>({
+          path: blocksChildrenList.path(args),
+          method: blocksChildrenList.method,
+          query: pick(args, blocksChildrenList.queryParams),
+          body: pick(args, blocksChildrenList.bodyParams),
+          auth: args.auth,
+        });
+      },
+    }
+  }
+
   public readonly databases = {
+    /**
+     * List databases
+     */
+    list: (args: WithAuth<DatabasesListParameters>): Promise<DatabasesListResponse> => {
+      return this.request<DatabasesListResponse>({
+        path: databasesList.path(),
+        method: databasesList.method,
+        query: pick(args, databasesList.queryParams),
+        body: pick(args, databasesList.bodyParams),
+        auth: args.auth,
+      });
+    },
+
     /**
      * Retrieve a database
      */
@@ -133,6 +185,88 @@ export default class Client {
       });
     },
   };
+
+  public readonly pages = {
+    /**
+     * Create a page
+     */
+    create: (args: WithAuth<PagesCreateParameters>): Promise<PagesCreateResponse> => {
+      return this.request<PagesCreateResponse>({
+        path: pagesCreate.path(),
+        method: pagesCreate.method,
+        query: pick(args, pagesCreate.queryParams),
+        body: pick(args, pagesCreate.bodyParams),
+        auth: args.auth,
+      });
+    },
+
+    /**
+     * Retrieve a page
+     */
+    retrieve: (args: WithAuth<PagesRetrieveParameters>): Promise<PagesRetrieveResponse> => {
+      return this.request<PagesRetrieveResponse>({
+        path: pagesRetrieve.path(args),
+        method: pagesRetrieve.method,
+        query: pick(args, pagesRetrieve.queryParams),
+        body: pick(args, pagesRetrieve.bodyParams),
+        auth: args.auth,
+      });
+    },
+
+    /**
+     * Update page properties
+     */
+    update: (args: WithAuth<PagesUpdateParameters>): Promise<PagesUpdateResponse> => {
+      return this.request<PagesUpdateResponse>({
+        path: pagesUpdate.path(args),
+        method: pagesUpdate.method,
+        query: pick(args, pagesUpdate.queryParams),
+        body: pick(args, pagesUpdate.bodyParams),
+        auth: args.auth,
+      });
+    },
+  };
+
+  public readonly users = {
+    /**
+     * Retrieve a user
+     */
+    retrieve: (args: WithAuth<UsersRetrieveParameters>): Promise<UsersRetrieveResponse> => {
+      return this.request<UsersRetrieveResponse>({
+        path: usersRetrieve.path(args),
+        method: usersRetrieve.method,
+        query: pick(args, usersRetrieve.queryParams),
+        body: pick(args, usersRetrieve.bodyParams),
+        auth: args.auth,
+      });
+    },
+
+    /**
+     * List all users
+     */
+    list: (args: WithAuth<UsersListParameters>): Promise<UsersListResponse> => {
+      return this.request<UsersListResponse>({
+        path: usersList.path(),
+        method: usersList.method,
+        query: pick(args, usersList.queryParams),
+        body: pick(args, usersList.bodyParams),
+        auth: args.auth,
+      });
+    },
+  };
+
+  /**
+   * Search
+   */
+  public search(args: WithAuth<SearchParameters>): Promise<SearchResponse> {
+    return this.request<SearchResponse>({
+      path: search.path(),
+      method: search.method,
+      query: pick(args, search.queryParams),
+      body: pick(args, search.bodyParams),
+      auth: args.auth,
+    });
+  }
 
   /**
    * Emits a log message to the console.

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
-
-import { NotionDatabase, NotionDatabaseFilter, NotionDatabaseSort, NotionPage, PaginatedList } from './api-types';
-
 /**
  * Notion API Endpoints
  *
@@ -9,7 +6,114 @@ import { NotionDatabase, NotionDatabaseFilter, NotionDatabaseSort, NotionPage, P
  * In the future, the contents of this file will be generated from an API definition.
  */
 
+import {
+  PaginatedList,
+  PaginationParameters,
+
+  Database,
+  Page,
+  ParentInput,
+  PropertyValue,
+  Block, BlockBase,
+  User, UserBase,
+
+  Filter,
+  Sort,
+  SearchSort,
+  SearchFilter,
+} from './api-types';
+
 // TODO: type assertions to verify that each interface is synchronized to the list of keys in the runtime value below.
+
+// TODO: instead of importing interfaces like BlockBase, should i use a type alias to Block?
+// TODO: need an input version of Block
+
+/*
+ * blocks.children.append()
+ */
+
+interface BlocksChildrenAppendPathParameters {
+  block_id: string;
+}
+interface BlocksChildrenAppendQueryParameters {}
+interface BlocksChildrenAppendBodyParameters {
+  children: Block[];
+}
+
+export interface BlocksChildrenAppendParameters extends BlocksChildrenAppendPathParameters, BlocksChildrenAppendQueryParameters, BlocksChildrenAppendBodyParameters {}
+export interface BlocksChildrenAppendResponse extends BlockBase {}
+
+export const blocksChildrenAppend = {
+  method: 'patch',
+  pathParams: ['block_id'],
+  queryParams: [],
+  bodyParams: ['children'],
+  path: (p: BlocksChildrenAppendPathParameters) => `blocks/${p.block_id}/children`,
+} as const;
+
+/*
+ * blocks.children.list()
+ */
+
+interface BlocksChildrenListPathParameters {
+  block_id: string;
+}
+interface BlocksChildrenListQueryParameters extends PaginationParameters {}
+interface BlocksChildrenListBodyParameters {}
+
+export interface BlocksChildrenListParameters extends BlocksChildrenListPathParameters, BlocksChildrenListQueryParameters, BlocksChildrenListBodyParameters {}
+export interface BlocksChildrenListResponse extends PaginatedList<Block> {}
+
+export const blocksChildrenList = {
+  method: 'get',
+  pathParams: ['block_id'],
+  queryParams: ['start_cursor', 'page_size'],
+  bodyParams: [],
+  path: (p: BlocksChildrenListPathParameters) => `blocks/${p.block_id}/children`,
+} as const;
+
+/*
+ * databases.list()
+ */
+
+interface DatabasesListPathParameters {}
+interface DatabasesListQueryParameters extends PaginationParameters {}
+interface DatabasesListBodyParameters {}
+
+export interface DatabasesListParameters extends DatabasesListPathParameters, DatabasesListQueryParameters, DatabasesListBodyParameters {}
+export interface DatabasesListResponse extends PaginatedList<Database> {}
+
+export const databasesList = {
+  method: 'get',
+  pathParams: [],
+  queryParams: ['start_cursor', 'page_size'],
+  bodyParams: [],
+  path: () => `databases`,
+} as const;
+
+/*
+ * databases.query()
+ */
+
+interface DatabasesQueryPathParameters {
+  database_id: string;
+}
+interface DatabasesQueryQueryParameters {}
+interface DatabasesQueryBodyParameters extends PaginationParameters {
+  filter?: Filter;
+  sorts?: Sort[];
+}
+
+export interface DatabasesQueryParameters extends DatabasesQueryPathParameters, DatabasesQueryQueryParameters, DatabasesQueryBodyParameters {}
+export interface DatabasesQueryResponse extends PaginatedList<Page> {}
+
+export const databasesQuery = {
+  method: 'post',
+  pathParams: ['database_id'],
+  queryParams: [],
+  bodyParams: ['filter', 'sorts', 'start_cursor', 'page_size'],
+  path: (p: DatabasesQueryPathParameters) => `databases/${p.database_id}`,
+} as const;
 
 /*
  * databases.retrieve()
@@ -22,11 +126,10 @@ interface DatabasesRetrieveQueryParameters {}
 interface DatabasesRetrieveBodyParameters {}
 
 export interface DatabasesRetrieveParameters extends DatabasesRetrievePathParameters, DatabasesRetrieveQueryParameters, DatabasesRetrieveBodyParameters {}
-export interface DatabasesRetrieveResponse extends NotionDatabase {}
+export interface DatabasesRetrieveResponse extends Database {}
 
 export const databasesRetrieve = {
   method: 'get',
-  // The following lists are synchronized with keyof DatabasesRetrievePathParams / DatabasesRetrieveQueryParameters / DatabasesRetrieveBodyParameters
   pathParams: ['database_id'],
   queryParams: [],
   bodyParams: [],
@@ -34,28 +137,131 @@ export const databasesRetrieve = {
 } as const;
 
 /*
- * databases.query()
+ * pages.create()
  */
 
-interface DatabasesQueryPathParameters {
-  database_id: string;
-}
-interface DatabasesQueryQueryParameters {}
-interface DatabasesQueryBodyParameters {
-  filter?: NotionDatabaseFilter;
-  sorts?: NotionDatabaseSort[];
-  start_cursor?: string;
+interface PagesCreatePathParameters {}
+interface PagesCreateQueryParameters {}
+interface PagesCreateBodyParameters {
+  parent: ParentInput;
+  properties: { [propertyName: string]: PropertyValue; };
+  children?: Block[];
 }
 
-export interface DatabasesQueryParameters extends DatabasesQueryPathParameters, DatabasesQueryQueryParameters, DatabasesQueryBodyParameters {}
-export interface DatabasesQueryResponse extends PaginatedList<NotionPage> {}
+export interface PagesCreateParameters extends PagesCreatePathParameters, PagesCreateQueryParameters, PagesCreateBodyParameters {}
+export interface PagesCreateResponse extends BlockBase {}
 
-export const databasesQuery = {
+export const pagesCreate = {
   method: 'post',
-  // The following lists are synchronized with keyof DatabasesQueryPathParams / DatabasesQueryQueryParams / DatabasesQueryBodyParams
-  pathParams: ['database_id'],
+  pathParams: [],
   queryParams: [],
-  bodyParams: ['filter', 'sorts', 'start_cursor'],
-  path: (p: DatabasesRetrievePathParameters) => `databases/${p.database_id}`,
+  bodyParams: ['parent', 'properties', 'children'],
+  path: () => `pages`,
+} as const
+
+/*
+ * pages.retrieve()
+ */
+
+interface PagesRetrievePathParameters {
+  page_id: string;
+}
+interface PagesRetrieveQueryParameters {}
+interface PagesRetrieveBodyParameters {}
+
+export interface PagesRetrieveParameters extends PagesRetrievePathParameters, PagesRetrieveQueryParameters, PagesRetrieveBodyParameters {}
+export interface PagesRetrieveResponse extends Page {}
+
+export const pagesRetrieve = {
+  method: 'get',
+  pathParams: ['page_id'],
+  queryParams: [],
+  bodyParams: [],
+  path: (p: PagesRetrievePathParameters) => `pages/${p.page_id}`,
 } as const;
 
+/*
+ * pages.update()
+ */
+
+interface PagesUpdatePathParameters {
+  page_id: string;
+}
+interface PagesUpdateQueryParameters {}
+interface PagesUpdateBodyParameters {
+  properties: { [propertyNameOrId: string]: PropertyValue; };
+}
+
+export interface PagesUpdateParameters extends PagesUpdatePathParameters, PagesUpdateQueryParameters, PagesUpdateBodyParameters {}
+export interface PagesUpdateResponse extends Page {}
+
+export const pagesUpdate = {
+  method: 'patch',
+  pathParams: ['page_id'],
+  queryParams: [],
+  bodyParams: ['properties'],
+  path: (p: PagesUpdatePathParameters) => `pages/${p.page_id}`,
+} as const;
+
+/*
+ * users.retrieve()
+ */
+
+interface UsersRetrievePathParameters {
+  user_id: string;
+}
+interface UsersRetrieveQueryParameters {}
+interface UsersRetrieveBodyParameters {}
+
+export interface UsersRetrieveParameters extends UsersRetrievePathParameters, UsersRetrieveQueryParameters, UsersRetrieveBodyParameters {}
+export interface UsersRetrieveResponse extends UserBase {}
+
+export const usersRetrieve = {
+  method: 'get',
+  pathParams: ['user_id'],
+  queryParams: [],
+  bodyParams: [],
+  path: (p: UsersRetrievePathParameters) => `users/${p.user_id}`,
+} as const;
+
+/*
+ * users.list()
+ */
+
+interface UsersListPathParameters {}
+interface UsersListQueryParameters extends PaginationParameters {}
+interface UsersListBodyParameters {}
+
+export interface UsersListParameters extends UsersListPathParameters, UsersListQueryParameters, UsersListBodyParameters {}
+export interface UsersListResponse extends PaginatedList<User> {}
+
+export const usersList = {
+  method: 'get',
+  pathParams: [],
+  queryParams: ['start_cursor', 'page_size'],
+  bodyParams: [],
+  path: () => `users`,
+} as const;
+
+/*
+ * search()
+ */
+
+interface SearchPathParameters {}
+interface SearchQueryParameters {}
+interface SearchBodyParameters extends PaginationParameters {
+  query?: string;
+  sort?: SearchSort;
+  filter?: SearchFilter;
+}
+
+export interface SearchParameters extends SearchPathParameters, SearchQueryParameters, SearchBodyParameters {}
+export interface SearchResponse extends PaginatedList<Page | Database> {}
+
+export const search = {
+  method: 'post',
+  pathParams: [],
+  queryParams: [],
+  bodyParams: ['query', 'sort', 'filter', 'start_cursor', 'page_size'],
+  path: () => `search`,
+} as const;

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -5,40 +5,700 @@
  * In the future, the contents of this file will be generated from an API definition.
  */
 
-export type NotionObject = NotionSingularObject | PaginatedList;
-export type NotionSingularObject = NotionDatabase | NotionPage;
 
-interface PropertyFilter {
-  property: string;
-  // title?: TextFilter;
-  // text?: TextFilter;
-  // number?: NumberFilter;
-  // checkbox?: CheckboxFilter;
-  // ...
+/*
+ * Pagination
+ */
+
+export interface PaginationParameters {
+  start_cursor?: string;
+  page_size?: number;
 }
 
+export interface PaginatedList<O extends APISingularObject = APISingularObject> {
+  object: 'list',
+  results: O[],
+  has_more: boolean;
+  next_cursor: string | null;
+}
 
-// TODO: fill in the rest of these types
-export interface NotionDatabase {
+/*
+ * API Objects
+ */
+
+export type APIObject = APISingularObject | PaginatedList;
+export type APISingularObject = Database | Page | User | Block;
+
+/*
+ * Block (outputs)
+ */
+
+// TODO: need an input version of this type. maybe reuse distributiveomit. but what about richtext id's?
+
+export type Block =
+  | ParagraphBlock
+  | HeadingOneBlock
+  | HeadingTwoBlock
+  | HeadingThreeBlock
+  | BulletedListItemBlock
+  | NumberedListItemBlock
+  | ToDoBlock
+  | ToggleBlock
+  | ChildPageBlock
+  | UnsupportedBlock;
+
+
+export interface BlockBase {
+  object: 'block';
+  id: string;
+  type: string;
+  created_time: string;
+  last_edited_time: string;
+  has_children: boolean;
+}
+
+export interface ParagraphBlock extends BlockBase {
+  type: 'paragraph';
+  text: RichText[];
+  children?: BlockBase[];
+}
+
+export interface HeadingOneBlock extends BlockBase {
+  type: 'heading_1';
+  text: RichText[];
+  has_children: false;
+}
+
+export interface HeadingTwoBlock extends BlockBase {
+  type: 'heading_2';
+  text: RichText[];
+  has_children: false;
+}
+
+export interface HeadingThreeBlock extends BlockBase {
+  type: 'heading_3';
+  text: RichText[];
+  has_children: false;
+}
+
+export interface BulletedListItemBlock extends BlockBase {
+  type: 'bulleted_list_item';
+  text: RichText[];
+  children?: BlockBase[];
+}
+
+export interface NumberedListItemBlock extends BlockBase {
+  type: 'numbered_list_item';
+  text: RichText[];
+  children?: BlockBase[];
+}
+
+export interface ToDoBlock extends BlockBase {
+  type: 'to_do';
+  text: RichText[];
+  checked: boolean;
+  children?: BlockBase[];
+}
+
+export interface ToggleBlock extends BlockBase {
+  type: 'toggle';
+  text: RichText[];
+  children?: BlockBase[];
+}
+
+export interface ChildPageBlock extends BlockBase {
+  type: 'child_page';
+  title: string;
+}
+
+export interface UnsupportedBlock extends BlockBase {
+  type: 'unsupported';
+}
+
+/*
+ * Database (outputs)
+ */
+
+export interface Database {
   object: 'database';
   id: string;
+  created_time: string;
+  last_edited_time: string;
+  title: RichText[];
+  properties: { [propertyName: string] : Property };
 }
-export type NotionDatabaseFilter = PropertyFilter; // | ...
-export interface NotionDatabaseSort {
-  // TODO: either property or timestamp are defined but not both
+
+/*
+ * Property (outputs)
+ */
+
+export type Property =
+  | TitleProperty
+  | RichTextProperty
+  | NumberProperty
+  | SelectProperty
+  | MultiSelectProperty
+  | DateProperty
+  | PeopleProperty
+  | FileProperty
+  | CheckboxProperty
+  | URLProperty
+  | EmailProperty
+  | PhoneNumberProperty
+  | FormulaProperty
+  | RelationProperty
+  | RollupProperty
+  | CreatedTimeProperty
+  | CreatedByProperty
+  | LastEditedTimeProperty
+  | LastEditedByProperty;
+
+export interface PropertyBase {
+  id: string;
+  type: string;
+}
+
+export interface TitleProperty extends PropertyBase {
+  type: 'title';
+  title: Record<string, never>;
+}
+
+export interface RichTextProperty extends PropertyBase {
+  type: 'rich_text';
+  rich_text: Record<string, never>;
+}
+
+export interface NumberProperty extends PropertyBase {
+  type: 'number';
+  number: {
+    format: 'number' | 'number_with_commas' | 'percent' | 'dollar' | 'euro' | 'pound' | 'yen' | 'ruble' | 'rupee' | 'won' | 'yuan';
+  }
+}
+
+export interface SelectProperty extends PropertyBase {
+  type: 'select';
+  select: SelectOption[];
+}
+
+export interface MultiSelectProperty extends PropertyBase {
+  type: 'multi_select';
+  multi_select: MultiSelectOption[];
+}
+
+export interface DateProperty extends PropertyBase {
+  type: 'date';
+  date: Record<string, never>;
+}
+
+export interface PeopleProperty extends PropertyBase {
+  type: 'people';
+  people: Record<string, never>;
+}
+
+export interface FileProperty extends PropertyBase {
+  type: 'file';
+  file: Record<string, never>;
+}
+
+export interface CheckboxProperty extends PropertyBase {
+  type: 'checkbox';
+  checkbox: Record<string, never>;
+}
+
+export interface URLProperty extends PropertyBase {
+  type: 'url';
+  url: Record<string, never>;
+}
+
+export interface EmailProperty extends PropertyBase {
+  type: 'email';
+  email: Record<string, never>;
+}
+
+export interface PhoneNumberProperty extends PropertyBase {
+  type: 'phone_number';
+  phone_number: Record<string, never>;
+}
+
+export interface FormulaProperty extends PropertyBase {
+  type: 'formula';
+  formula: {
+    expression: string;
+  };
+}
+
+export interface RelationProperty extends PropertyBase {
+  type: 'relation';
+  relation: {
+    database_id: string;
+    synced_property_name?: string;
+    synced_property_id?: string;
+  }
+}
+
+export interface RollupProperty extends PropertyBase {
+  type: 'rollup';
+  rollup: {
+    relation_property_name: string;
+    relation_property_id: string;
+    rollup_property_name: string;
+    rollup_property_id: string;
+    function: 'count_all' | 'count_values' | 'count_unique_values' | 'count_empty' | 'count_not_empty' | 'percent_empty' | 'percent_not_empty' | 'sum' | 'average' | 'median' | 'min' | 'max' | 'range';
+  }
+}
+
+export interface CreatedTimeProperty extends PropertyBase {
+  type: 'created_time';
+  created_time: Record<string, never>;
+}
+
+export interface CreatedByProperty extends PropertyBase {
+  type: 'created_by';
+  created_by: Record<string, never>;
+}
+
+export interface LastEditedTimeProperty extends PropertyBase {
+  type: 'last_edited_time';
+  last_edited_time: Record<string, never>;
+}
+
+export interface LastEditedByProperty extends PropertyBase {
+  type: 'last_edited_by';
+  last_edited_by: Record<string, never>;
+}
+
+/*
+ * User (output)
+ */
+
+export type User = PersonUser | BotUser;
+
+export interface UserBase {
+  object: 'user';
+  id: string;
+  type?: string;
+  name?: string;
+  avatar_url?: string;
+}
+
+export interface PersonUser extends UserBase {
+  type?: 'person';
+  person?: {
+    email: string;
+  };
+}
+
+export interface BotUser extends UserBase {
+  type?: 'bot';
+}
+
+
+/*
+ * Misc (output)
+ */
+
+export interface SelectOption {
+  name: string;
+  id: string;
+  color: Color;
+}
+
+export interface MultiSelectOption {
+  name: string;
+  id: string;
+  color: Color;
+}
+
+
+export interface SearchSort {
+  direction: 'ascending' | 'descending';
+  timestamp: 'last_edited_time';
+}
+
+export interface SearchFilter {
+  value: 'object',
+  property: 'object';
+}
+
+export type Color = 'default' | 'gray' | 'brown' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'red';
+export type BackgroundColor = 'gray_background' | 'brown_background' | 'orange_background' | 'yellow_background' | 'green_background' | 'blue_background' | 'purple_background' | 'pink_background' | 'red_background';
+
+/*
+ * Filter (input)
+ */
+
+export type Filter = SinglePropertyFilter | CompoundFilter;
+
+export type SinglePropertyFilter =
+  | TextFilter
+  | NumberFilter
+  | CheckboxFilter
+  | SelectFilter
+  | MultiSelectFilter
+  | DateFilter
+  | PeopleFilter
+  | FilesFilter
+  | RelationFilter
+  | FormulaFilter
+
+export interface CompoundFilter {
+  or?: Filter[];
+  and?: Filter[];
+}
+
+export interface SinglePropertyFilterBase {
+  property: string;
+}
+
+export interface TextFilter extends SinglePropertyFilterBase {
+  equals?: string;
+  does_not_equal?: string;
+  contains?: string;
+  does_not_contain?: string;
+  starts_with?: string;
+  ends_with?: string;
+  is_empty?: true;
+  is_not_empty?: true;
+}
+
+export interface NumberFilter extends SinglePropertyFilterBase {
+  equals?: number;
+  does_not_equal?: number;
+  greater_than?: number;
+  less_than?: number;
+  greater_than_or_equal_to?: number;
+  less_than_or_equal_to?: number;
+  is_empty?: true;
+  is_not_empty?: true;
+}
+
+export interface CheckboxFilter extends SinglePropertyFilterBase {
+  equals?: boolean;
+  does_not_equal?: boolean;
+}
+
+export interface SelectFilter extends SinglePropertyFilterBase {
+  equals?: string;
+  does_not_equal?: string;
+  is_empty?: true;
+  is_not_empty?: true;
+}
+
+export interface MultiSelectFilter extends SinglePropertyFilterBase {
+  contains?: string;
+  does_not_contain?: string;
+  is_empty?: true;
+  is_not_empty?: true;
+}
+
+export interface DateFilter extends SinglePropertyFilterBase {
+  equals?: string;
+  before?: string;
+  after?: string;
+  on_or_before?: string;
+  is_empty?: true;
+  is_not_empty?: true;
+  on_or_after?: string;
+  past_week: Record<string, never>;
+  past_month: Record<string, never>;
+  past_year: Record<string, never>;
+  next_week: Record<string, never>;
+  next_month: Record<string, never>;
+  next_year: Record<string, never>;
+}
+
+export interface PeopleFilter extends SinglePropertyFilterBase {
+  contains?: string;
+  does_not_contain?: string;
+  is_empty?: true;
+  is_not_empty?: true;
+}
+
+export interface FilesFilter extends SinglePropertyFilterBase {
+  is_empty?: true;
+  is_not_empty?: true;
+}
+
+export interface RelationFilter extends SinglePropertyFilterBase {
+  contains?: string;
+  does_not_contain?: string;
+  is_empty?: true;
+  is_not_empty?: true;
+}
+
+export interface FormulaFilter extends SinglePropertyFilterBase {
+  text?: Omit<TextFilter, 'property'>;
+  checkbox?: Omit<CheckboxFilter, 'property'>;
+  number?: Omit<NumberFilter, 'property'>;
+  date?: Omit<DateFilter, 'property'>;
+}
+
+/*
+ * Sort (input)
+ */
+
+export interface Sort {
   property?: string;
   timestamp?: 'created_time' | 'last_edited_time';
   direction: 'ascending' | 'descending';
 }
 
-export interface NotionPage {
+/*
+ * Page
+ */
+
+export interface Page {
   object: 'page',
   id: string;
+  parent: Parent;
+  properties: { [propertyName: string]: PropertyValue };
 }
 
-export interface PaginatedList<O extends NotionSingularObject = NotionSingularObject> {
-  object: 'list',
-  results: O[],
-  has_more: boolean;
-  next_cursor: string | null;
+/*
+ * Parent
+ */
+
+export type Parent = DatabaseParent | PageParent | WorkspaceParent;
+export type ParentInput = Omit<DatabaseParent, 'type'> |  Omit<PageParent, 'type'>;
+// TODO: use distributiveomit?
+
+export interface DatabaseParent {
+  type: 'database_id';
+  database_id: string;
+}
+
+export interface PageParent {
+  type: 'page_id';
+  page_id: string;
+}
+
+export interface WorkspaceParent {
+  type: 'workspace';
+}
+
+
+/*
+ * PropertyValue
+ */
+
+// TODO: use the following type to omit id properties and create an input version of this type?
+// type DistributiveOmit<T, K extends keyof T> = T extends unknown
+//     ? Omit<T, K>
+//     : never;
+
+export type PropertyValue =
+ | TitlePropertyValue
+ | RichTextPropertyValue
+ | NumberPropertyValue
+ | SelectPropertyValue
+ | MultiSelectPropertyValue
+ | DatePropertyValue
+ | FormulaPropertyValue
+ | RollupPropertyValue
+ | PeoplePropertyValue
+ | FilesPropertyValue
+ | CheckboxPropertyValue
+ | URLPropertyValue
+ | EmailPropertyValue
+ | PhoneNumberPropertyValue
+ | CreatedTimePropertyValue
+ | CreatedByPropertyValue
+ | LastEditedTimePropertyValue
+ | LastEditedByPropertyValue;
+
+export interface PropertyValueBase {
+  id: string;
+  type: string;
+}
+
+export interface TitlePropertyValue extends PropertyValueBase {
+  type: 'title';
+  title: RichText[];
+}
+
+export interface RichTextPropertyValue extends PropertyValueBase {
+  type: 'rich_text';
+  rich_text: RichText[];
+}
+
+export interface NumberPropertyValue extends PropertyValueBase {
+  type: 'number';
+  number: number;
+}
+
+export interface SelectPropertyValue extends PropertyValueBase {
+  type: 'select';
+  select: {
+    id: string;
+    name: string;
+    color: Color;
+  };
+}
+
+export interface MultiSelectPropertyValue extends PropertyValueBase {
+  type: 'multi_select';
+  multi_select: {
+    id: string;
+    name: string;
+    color: Color;
+  };
+}
+
+export interface DatePropertyValue extends PropertyValueBase {
+  type: 'date';
+  date: {
+    start: string;
+    end?: string;
+  };
+}
+
+export interface FormulaPropertyValue extends PropertyValueBase {
+  type: 'formula';
+  formula: StringFormulaValue | NumberFormulaValue | BooleanFormulaValue | DateFormulaValue;
+}
+
+export interface StringFormulaValue {
+  type: 'string';
+  string?: string;
+}
+export interface NumberFormulaValue {
+  type: 'number';
+  number?: number;
+}
+export interface BooleanFormulaValue {
+  type: 'boolean';
+  boolean: boolean;
+}
+export interface DateFormulaValue {
+  type: 'date';
+  date: DatePropertyValue;
+}
+
+export interface RollupPropertyValue extends PropertyValueBase {
+  type: 'rollup';
+  rollup: NumberRollupValue | DateRollupValue | ArrayRollupValue;
+}
+
+export interface NumberRollupValue {
+  type: 'number';
+  number: number;
+}
+export interface DateRollupValue {
+  type: 'date';
+  date: DatePropertyValue;
+}
+export interface ArrayRollupValue {
+  type: 'array';
+  array: unknown[]; // TODO: this is exactly like PropertyValue but without the `id`
+}
+
+export interface PeoplePropertyValue extends PropertyValueBase {
+  type: 'people';
+  people: User[];
+}
+
+export interface FilesPropertyValue extends PropertyValueBase {
+  type: 'files';
+  files: { name: string; }[];
+}
+
+export interface CheckboxPropertyValue extends PropertyValueBase {
+  type: 'checkbox';
+  checkbox: boolean;
+}
+
+export interface URLPropertyValue extends PropertyValueBase {
+  type: 'url';
+  url: string;
+}
+
+export interface EmailPropertyValue extends PropertyValueBase {
+  type: 'email';
+  email: string;
+}
+
+export interface PhoneNumberPropertyValue extends PropertyValueBase {
+  type: 'phone_number';
+  phone_number: string;
+}
+
+export interface CreatedTimePropertyValue extends PropertyValueBase {
+  type: 'created_time';
+  created_time: string;
+}
+
+export interface CreatedByPropertyValue extends PropertyValueBase {
+  type: 'created_by';
+  created_by: User;
+}
+
+export interface LastEditedTimePropertyValue extends PropertyValueBase {
+  type: 'last_edited_time';
+  last_edited_time: string;
+}
+
+export interface LastEditedByPropertyValue extends PropertyValueBase {
+  type: 'last_edited_by';
+  last_edited_by: User;
+}
+
+/*
+ * Rich text object (output)
+ */
+export type RichText = RichTextText | RichTextMention | RichTextEquation;
+
+export interface RichTextBase {
+  plain_text: string;
+  href?: string;
+  annotations: Annotations;
+  type: string;
+}
+
+export interface RichTextText extends RichTextBase {
+  type: 'text';
+  text: {
+    content: string;
+    link?: { type: 'url'; url: string; };
+  };
+}
+
+export interface RichTextMention extends RichTextBase {
+  type: 'mention';
+  mention: UserMention | PageMention | DatabaseMention | DateMention;
+}
+
+export interface UserMention {
+  type: 'user';
+  user: User;
+}
+
+export interface PageMention {
+  type: 'page';
+  page: { id: string; };
+}
+
+export interface DatabaseMention {
+  type: 'database';
+  database: { id: string };
+}
+
+export interface DateMention {
+  type: 'date';
+  date: DatePropertyValue;
+}
+
+export interface RichTextEquation extends RichTextBase {
+  type: 'equation';
+  equation: {
+    expression: string;
+  };
+}
+
+export interface Annotations {
+  bold: boolean;
+  italic: boolean;
+  strikethrough: boolean;
+  underline: boolean;
+  code: boolean;
+  color: Color | BackgroundColor;
 }


### PR DESCRIPTION
This change adds named methods to the `Client` class for each of the endpoints in the Notion API. It follows the pattern established in #1.

Fixes #13

### Future work

It's clear that the type definitions are not ideal. I intentionally avoided complex type constructs such as conditional types and heavy use of generics because the eventual goal is to generate these types from an OpenAPI format. If we used these more complex types now, it's very unlikely we could generate something which kept stability in the type names. TypeScript is just more expressive than OpenAPI and JSON Schema.

Another shortcoming is that there isn't a good separation between "input" types and "output" types. This matters in situations where a method accepts, for example, a `Block` in its parameters. At call time, a block won't have properties like `id` - those are assigned by the server. However, the `Block` type has `id` set as a non-optional property. This is a real issue and should be handled in a bugfix.