### PR TITLE
fix another link to example

### DIFF
--- a/examples/github-issue-sync/README.md
+++ b/examples/github-issue-sync/README.md
@@ -29,7 +29,7 @@ GITHUB_REPO_OWNER=<github-owner-username>
 GITHUB_REPO_NAME=<github-repo-name>
 ```
 
-You can create your Notion API key [here](www.notion.com/integrations).
+You can create your Notion API key [here](www.notion.com/my-integrations).
 
 You can create your GitHub Personal Access token by following the guide [here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
 


### PR DESCRIPTION
I followed the descriptions on README.md and pressed "here" hyperlinked for the Notion API Key Create, but it was not redirected to the appropriate link.

So I fix it.