### PR TITLE
Fix search filter value type

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -316,7 +316,7 @@ export interface SearchSort {
 }
 
 export interface SearchFilter {
-  value: 'object',
+  value: 'page' | 'database',
   property: 'object';
 }
 


### PR DESCRIPTION
# Background
Currently the search endpoint only supports filtering by the `'object'` property with possible values of `'page'` or `'database'`.

To do this with the SDK, you would do:
```typescript
const response = await notion.search({
  filter: {
    property: 'object',
    value: 'database',
  },
});
```

# Problem
The current type for `value` is the string literal `'object'` instead of `'page' | 'database'` which prevents TypeScript from compiling.

# Solution
Fixes the `SearchFilter` `value` type to be `'page' | 'database'`.