### PR TITLE
fix: fix page type

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -450,6 +450,9 @@ export interface Sort {
 export interface Page {
   object: 'page',
   id: string;
+  created_time: string;
+  last_edited_time: string;
+  archived: boolean;
   parent: Parent;
   properties: { [propertyName: string]: PropertyValue };
 }


### PR DESCRIPTION
https://developers.notion.com/reference/page

Page type and document comparison lack created_time, last_edited_time, archived attributes.