### PR TITLE
Add default args for 'list' operations

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -149,7 +149,7 @@ export default class Client {
     /**
      * List databases
      */
-    list: (args: WithAuth<DatabasesListParameters>): Promise<DatabasesListResponse> => {
+    list: (args: WithAuth<DatabasesListParameters> = {}): Promise<DatabasesListResponse> => {
       return this.request<DatabasesListResponse>({
         path: databasesList.path(),
         method: databasesList.method,
@@ -244,7 +244,7 @@ export default class Client {
     /**
      * List all users
      */
-    list: (args: WithAuth<UsersListParameters>): Promise<UsersListResponse> => {
+    list: (args: WithAuth<UsersListParameters> = {}): Promise<UsersListResponse> => {
       return this.request<UsersListResponse>({
         path: usersList.path(),
         method: usersList.method,


### PR DESCRIPTION
List users and list databases don't require and arguments and the
examples in the documentation don't provide any arguments, for example:

    notion.users.list()

Source: https://github.com/makenotion/notion-sdk-js#usage

However, when using this function in TypeScript, this example produces an
error:

> Expected 1 arguments, but got 0.ts(2554)
> Client.d.ts(84, 16): An argument for 'args' was not provided.

This is because `list()` requires an argument, even though all the properties of that argument are optional. To workaround the error, the developer has to provide an empty object:

    notion.users.list({})

This change sets a default argument of an empty object (`{}`) so the examples in the documentation work when using TypeScript and an argument is no longer needed.

Thanks for your great work on this API and SDK!