### PR TITLE
Clean up example code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,10 +3,76 @@
 module.exports = {
 	root: true,
 	parser: "@typescript-eslint/parser",
-	plugins: ["@typescript-eslint"],
+	parserOptions: {
+		tsconfigRootDir: __dirname,
+		project: "./tsconfig.json",
+		sourceType: "module",
+	},
+	plugins: ["@typescript-eslint", "unused-imports", "formatjs", "import"],
 	extends: [
 		"eslint:recommended",
 		"plugin:@typescript-eslint/eslint-recommended",
 		"plugin:@typescript-eslint/recommended",
 	],
+	rules: {
+		"@typescript-eslint/await-thenable": "error",
+		"@typescript-eslint/no-floating-promises": "error",
+		"@typescript-eslint/no-misused-promises": [
+			"error",
+			{
+				// TODO(lint): Remove this.
+				checksVoidReturn: false,
+			},
+		],
+		"@typescript-eslint/require-await": "error",
+		"@typescript-eslint/semi": ["error", "never"],
+		// https://github.com/sweepline/eslint-plugin-unused-imports
+		"@typescript-eslint/no-unused-vars": "off",
+		"unused-imports/no-unused-imports": [
+			"error",
+			{
+				varsIgnorePattern: "^_",
+			},
+		],
+		"unused-imports/no-unused-vars": [
+			"error",
+			{
+				args: "none",
+				argsIgnorePattern: "^_",
+				caughtErrors: "none",
+				ignoreRestSiblings: true,
+				varsIgnorePattern: "^_",
+			},
+		],
+		curly: "error",
+		eqeqeq: ["error", "always"],
+		"no-console": [
+			"error",
+			{
+				allow: [
+					"info",
+					"group",
+					"groupCollapsed",
+					"groupEnd",
+					"table",
+					"time",
+					"timeEnd",
+				],
+			},
+		],
+		"formatjs/enforce-default-message": "error",
+		"formatjs/enforce-placeholders": "error",
+		"formatjs/enforce-plural-rules": [
+			2,
+			{
+				one: true,
+				other: true,
+				zero: false,
+			},
+		],
+		"formatjs/no-multiple-whitespaces": "error",
+		"no-debugger": "error",
+		"prefer-const": "error",
+		"prefer-template": "error",
+	},
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,12 @@
 /* eslint-env node */
 
 module.exports = {
-  root: true,
-  parser: '@typescript-eslint/parser',
-  plugins: [
-    '@typescript-eslint'
-  ],
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended'
-  ],
-};
+	root: true,
+	parser: "@typescript-eslint/parser",
+	plugins: ["@typescript-eslint"],
+	extends: [
+		"eslint:recommended",
+		"plugin:@typescript-eslint/eslint-recommended",
+		"plugin:@typescript-eslint/recommended",
+	],
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,12 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build-and-test:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -19,11 +18,11 @@ jobs:
         node-version: [14.x, 15.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+	"arrowParens": "avoid",
+	"semi": false,
+	"useTabs": true,
+	"trailingComma": "es5",
+	"endOfLine": "lf"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,3 @@
 {
-  "cSpell.words": [
-    "notionhq"
-  ]
+	"cSpell.words": ["notionhq"]
 }

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ npm install @notionhq/client
 Import and initialize a client using an **integration token** or an OAuth **access token**.
 
 ```js
-const { Client } = require('@notionhq/client');
+const { Client } = require("@notionhq/client")
 
 // Initializing a client
 const notion = new Client({
-  auth: process.env.NOTION_TOKEN,
-});
+	auth: process.env.NOTION_TOKEN,
+})
 ```
 
 Make a request to any Notion API endpoint.
@@ -36,47 +36,45 @@ Make a request to any Notion API endpoint.
 > See the complete list of endpoints in the [API reference](https://developers.notion.com/reference).
 
 ```js
-(async () => {
-
-  const listUsersResponse = await notion.users.list();
-
-})();
+;(async () => {
+	const listUsersResponse = await notion.users.list()
+})()
 ```
 
 Each method returns a `Promise` which resolves the response.
 
 ```js
-  console.log(listUsersResponse);
+console.log(listUsersResponse)
 
-  // {
-  //   results: [
-  //     {
-  //       object: 'user',
-  //       id: 'd40e767c-d7af-4b18-a86d-55c61f1e39a4',
-  //       type: 'person',
-  //       person: {
-  //         email: 'avo@example.org',
-  //       },
-  //       name: 'Avocado Lovelace',
-  //       avatar_url: 'https://secure.notion-static.com/e6a352a8-8381-44d0-a1dc-9ed80e62b53d.jpg',
-  //     },
-  //     ...
-  //   ]
-  // }
+// {
+//   results: [
+//     {
+//       object: 'user',
+//       id: 'd40e767c-d7af-4b18-a86d-55c61f1e39a4',
+//       type: 'person',
+//       person: {
+//         email: 'avo@example.org',
+//       },
+//       name: 'Avocado Lovelace',
+//       avatar_url: 'https://secure.notion-static.com/e6a352a8-8381-44d0-a1dc-9ed80e62b53d.jpg',
+//     },
+//     ...
+//   ]
+// }
 ```
 
 Endpoint parameters are grouped into a single object. You don't need to remember which parameters go in the path, query, or body.
 
 ```js
 const myPage = await notion.databases.query({
-  database_id: '897e5a76-ae52-4b48-9fdf-e71f5945d1af',
-  filter: {
-    property: 'Landmark',
-    text: {
-      contains: 'Bridge',
-    },
-  },
-});
+	database_id: "897e5a76-ae52-4b48-9fdf-e71f5945d1af",
+	filter: {
+		property: "Landmark",
+		text: {
+			contains: "Bridge",
+		},
+	},
+})
 ```
 
 ### Handling errors
@@ -86,27 +84,27 @@ If the API returns an unsuccessful response, the returned `Promise` rejects with
 The error contains properties from the response, and the most helpful is `code`. You can compare `code` to the values in the `APIErrorCode` object to avoid misspelling error codes.
 
 ```js
-const { Client, APIErrorCode } = require('@notionhq/client');
+const { Client, APIErrorCode } = require("@notionhq/client")
 
 try {
-  const myPage = await notion.databases.query({
-    database_id: databaseId,
-    filter: {
-      property: 'Landmark',
-      text: {
-        contains: 'Bridge',
-      },
-    },
-  });
+	const myPage = await notion.databases.query({
+		database_id: databaseId,
+		filter: {
+			property: "Landmark",
+			text: {
+				contains: "Bridge",
+			},
+		},
+	})
 } catch (error) {
-  if (error.code === APIErrorCode.ObjectNotFound) {
-    //
-    // For example: handle by asking the user to select a different database
-    //
-  } else {
-    // Other error handling code
-    console.error(error);
-  }
+	if (error.code === APIErrorCode.ObjectNotFound) {
+		//
+		// For example: handle by asking the user to select a different database
+		//
+	} else {
+		// Other error handling code
+		console.error(error)
+	}
 }
 ```
 
@@ -117,12 +115,12 @@ The client emits useful information to a logger. By default, it only emits warni
 If you're debugging an application, and would like the client to log response bodies, set the `logLevel` option to `LogLevel.DEBUG`.
 
 ```js
-const { Client, LogLevel } = require('@notionhq/client');
+const { Client, LogLevel } = require("@notionhq/client")
 
 const notion = new Client({
-  auth: process.env.NOTION_TOKEN,
-  logLevel: LogLevel.DEBUG,
-});
+	auth: process.env.NOTION_TOKEN,
+	logLevel: LogLevel.DEBUG,
+})
 ```
 
 You may also set a custom `logger` to emit logs to a destination other than `stdout`. A custom logger is a function which is called with 3 parameters: `logLevel`, `message`, and `extraInfo`. The custom logger should not return a value.
@@ -131,14 +129,14 @@ You may also set a custom `logger` to emit logs to a destination other than `std
 
 The `Client` supports the following options on initialization. These options are all keys in the single constructor parameter.
 
-| Option | Default value | Type | Description |
-|--------|---------------|---------|-------------|
-| `auth` | `undefined` | `string` | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request. |
-| `logLevel` | `LogLevel.WARN` | `LogLevel` | Verbosity of logs the instance will prodice. By default, logs are written to `stdout`.
-| `timeoutMs` | `60_000` | `number` | Number of milliseconds to wait before emitting a `RequestTimeoutError` |
-| `baseUrl` | `"https://api.notion.com"` | `string` | The root URL for sending API requests. This can be changed to test with a mock server. |
-| `logger` | Log to console | `Logger` | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`. |
-| `agent` | Default node agent | `http.Agent` | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent) |
+| Option      | Default value              | Type         | Description                                                                                                                                                  |
+| ----------- | -------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `auth`      | `undefined`                | `string`     | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request.                                                      |
+| `logLevel`  | `LogLevel.WARN`            | `LogLevel`   | Verbosity of logs the instance will prodice. By default, logs are written to `stdout`.                                                                       |
+| `timeoutMs` | `60_000`                   | `number`     | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                                       |
+| `baseUrl`   | `"https://api.notion.com"` | `string`     | The root URL for sending API requests. This can be changed to test with a mock server.                                                                       |
+| `logger`    | Log to console             | `Logger`     | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`.                       |
+| `agent`     | Default node agent         | `http.Agent` | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent) |
 
 ### TypeScript
 
@@ -148,31 +146,34 @@ Error classes, such as `RequestTimeoutError` and `APIResponseError`, contain typ
 
 ```ts
 try {
-  const response = notion.databases.query({ /* ... */ });
+	const response = notion.databases.query({
+		/* ... */
+	})
 } catch (error: unknown) {
-  if (APIResponseError.isAPIResponseError(error)) {
-    // error is now strongly typed to APIResponseError
-    switch (error.code) {
-      case APIErrorCode.ObjectNotFound:
-        // ...
-        break;
-      case APIErrorCode.Unauthorized:
-        // ...
-        break;
-      // ...
-      default:
-        // you could even take advantage of exhaustiveness checking
-        assertNever(error.code);
-    }
-  }
+	if (APIResponseError.isAPIResponseError(error)) {
+		// error is now strongly typed to APIResponseError
+		switch (error.code) {
+			case APIErrorCode.ObjectNotFound:
+				// ...
+				break
+			case APIErrorCode.Unauthorized:
+				// ...
+				break
+			// ...
+			default:
+				// you could even take advantage of exhaustiveness checking
+				assertNever(error.code)
+		}
+	}
 }
 ```
 
 ## Requirements
 
 This package supports the following minimum versions:
-* Runtime: `node >= 14`
-* Type definitions (optional): `typescript >= 4.2`
+
+- Runtime: `node >= 14`
+- Type definitions (optional): `typescript >= 4.2`
 
 Earlier versions may still work, but we encourage people building new applications to upgrade to the current stable.
 

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,9 +1,9 @@
 export default {
-  typescript: {
-    rewritePaths: {
-      'src/': 'build/src/',
-      'test/': 'build/test/'
-    },
-    compile: 'tsc',
-  },
-};
+	typescript: {
+		rewritePaths: {
+			"src/": "build/src/",
+			"test/": "build/test/",
+		},
+		compile: "tsc",
+	},
+}

--- a/examples/database-update-send-email/README.md
+++ b/examples/database-update-send-email/README.md
@@ -1,31 +1,33 @@
-# Sample Integration: Notion to Email 
+# Sample Integration: Notion to Email
 
 <img src="https://dev.notion.so/front-static/external/readme/images/notion-email-example@2x.png" alt="drawing" width="500"/>
 
-## About the Integration 
+## About the Integration
 
-This Notion integration sends an email whenever the Status of a page in a database is updated. This sample was built using [this database template](https://www.notion.so/5b593126d3eb401db62c83cbe362d2d5?v=a44397b3675545f389a6f28282c402ae) and emails are sent using [SendGrid's API](https://sendgrid.com). 
+This Notion integration sends an email whenever the Status of a page in a database is updated. This sample was built using [this database template](https://www.notion.so/5b593126d3eb401db62c83cbe362d2d5?v=a44397b3675545f389a6f28282c402ae) and emails are sent using [SendGrid's API](https://sendgrid.com).
 
 ## Running Locally
 
 ### 1. Setup your local project
+
 ```zsh
-# Clone this repository locally 
-git clone https://github.com/makenotion/notion-sdk-js.git 
+# Clone this repository locally
+git clone https://github.com/makenotion/notion-sdk-js.git
 
 # Switch into this project
-cd notion-sdk-js/examples/database-update-send-email 
+cd notion-sdk-js/examples/database-update-send-email
 
-# Install the dependencies 
+# Install the dependencies
 npm install
 ```
 
 ### 2. Set your enviornment variables in a `.env` file
+
 ```zsh
 NOTION_KEY= <your-notion-api-key>
 SENDGRID_KEY=<your-sendgrid-api-key>
 NOTION_DATABASE_ID=<your-notion-database-id>
-EMAIL_TO_FIELD=<email-receipients> 
+EMAIL_TO_FIELD=<email-receipients>
 EMAIL_FROM_FIELD=<email-from-field>
 ```
 
@@ -35,7 +37,7 @@ You can create your SendGrid API key [here](https://signup.sendgrid.com).
 
 To create a Notion database that will work with this example, duplicate [this template](https://www.notion.so/5b593126d3eb401db62c83cbe362d2d5?v=a44397b3675545f389a6f28282c402ae).
 
-### 3. Run code 
+### 3. Run code
 
 ```zsh
 node index.js

--- a/examples/database-update-send-email/index.js
+++ b/examples/database-update-send-email/index.js
@@ -1,110 +1,120 @@
-const {Client} = require("@notionhq/client")
-const dotenv = require("dotenv")
-const sgMail = require('@sendgrid/mail')
+// Find the official Notion API client @ https:// github.com/makenotion/notion-sdk-js/
+// npm install @notionhq/client
+const { Client } = require("@notionhq/client");
+
+const dotenv = require("dotenv");
 dotenv.config();
 
-sgMail.setApiKey(process.env.SENDGRID_KEY)
-const notion = new Client({auth:process.env.NOTION_KEY}); 
+const sgMail = require("@sendgrid/mail");
+sgMail.setApiKey(process.env.SENDGRID_KEY);
+
+const notion = new Client({ auth: process.env.NOTION_KEY });
 
 const database_id = process.env.NOTION_DATABASE_ID;
 
-//A JSON Object to hold all tasks in the Notion database
-let tasksInDatabase = {}
+// A JSON Object to hold all tasks in the Notion database
+let tasksInDatabase = {};
 
 async function findChangesAndSendEmails() {
-    console.log("Looking for changes in Notion database ")
-    //Get the tasks currently in the database
-    const currTasksInDatabase = await getTasksFromDatabase()
+  console.log("Looking for changes in Notion database ");
+  // Get the tasks currently in the database
+  const currTasksInDatabase = await getTasksFromDatabase();
 
-    //Iterate over the current tasks and compare them to tasks in our local store (tasksInDatabase)
-    for (const [key,value] of Object.entries(currTasksInDatabase)){
-        const page_id = key; 
-        const curr_status = value.Status;
-        //If this task hasn't been seen before
-        if(!(page_id) in tasksInDatabase){
-            //Add this task to the local store of all tasks
-            tasksInDatabase[page_id] = {
-                "Status": curr_status
-            }; 
-        } else {
-            //If the current status is different from the status in the local store
-            if(curr_status !== tasksInDatabase[page_id].Status){
-                //Change the local store. 
-                tasksInDatabase[page_id] = {
-                    "Status": curr_status
-                }
-                //Send an email about this change. 
-                const msg = {
-                    to:process.env.EMAIL_TO_FIELD, 
-                    from:process.env.EMAIL_FROM_FIELD, 
-                    subject:'Notion Task Status Updated', 
-                    text:"A Notion task's: " + value.Title + " status has been updated to " + curr_status + "."
-                }
-                sgMail.send(msg).then(() => {
-                    console.log("Email Sent")
-                }).catch((error) => {
-                    console.error(error)
-                })
-                console.log("Status Changed")
-            } 
-        }
+  // Iterate over the current tasks and compare them to tasks in our local store (tasksInDatabase)
+  for (const [key, value] of Object.entries(currTasksInDatabase)) {
+    const page_id = key;
+    const curr_status = value.Status;
+    // If this task hasn't been seen before
+    if (!page_id in tasksInDatabase) {
+      // Add this task to the local store of all tasks
+      tasksInDatabase[page_id] = {
+        Status: curr_status,
+      };
+    } else {
+      // If the current status is different from the status in the local store
+      if (curr_status !== tasksInDatabase[page_id].Status) {
+        // Change the local store.
+        tasksInDatabase[page_id] = {
+          Status: curr_status,
+        };
+        // Send an email about this change.
+        const msg = {
+          to: process.env.EMAIL_TO_FIELD,
+          from: process.env.EMAIL_FROM_FIELD,
+          subject: "Notion Task Status Updated",
+          text:
+            "A Notion task's: " +
+            value.Title +
+            " status has been updated to " +
+            curr_status +
+            ".",
+        };
+        sgMail
+          .send(msg)
+          .then(() => {
+            console.log("Email Sent");
+          })
+          .catch((error) => {
+            console.error(error);
+          });
+        console.log("Status Changed");
+      }
     }
-    //Run this method every 5 seconds (5000 milliseconds)
-    setTimeout(main, 5000)
+  }
+  // Run this method every 5 seconds (5000 milliseconds)
+  setTimeout(main, 5000);
 }
 
-function main(){
-    findChangesAndSendEmails().catch(console.error); 
+function main() {
+  findChangesAndSendEmails().catch(console.error);
 }
 
 (async () => {
-    tasksInDatabase = await getTasksFromDatabase(); 
-    main(); 
-})()
+  tasksInDatabase = await getTasksFromDatabase();
+  main();
+})();
 
-//Get a paginated list of Tasks currently in a the database. 
+// Get a paginated list of Tasks currently in a the database.
 async function getTasksFromDatabase() {
+  const tasks = {};
 
-    const tasks = {} 
-
-    async function getPageOfTasks(cursor){
-        let request_payload = "";
-        //Create the request payload based on the presense of a start_cursor
-        if(cursor == undefined){
-            request_payload = {
-                path:'databases/' + database_id + '/query', 
-                method:'POST',
-            }
-        } else {
-            request_payload= {
-                path:'databases/' + database_id + '/query', 
-                method:'POST',
-                body:{
-                    "start_cursor": cursor
-                }
-            }
-        }
-        //While there are more pages left in the query, get pages from the database. 
-        const current_pages = await notion.request(request_payload)
-        
-        for(const page of current_pages.results){
-            if(page.properties.Status){ 
-                tasks[page.id] = {
-                    "Status": page.properties.Status.select.name,
-                    "Title": page.properties.Name.title[0].text.content
-                }
-            } else {
-                tasks[page.id] = {
-                    "Status": "No Status",
-                    "Title": page.properties.Name.title[0].text.content
-                }
-            }
-        }
-        if(current_pages.has_more){
-            await getPageOfTasks(current_pages.next_cursor)
-        }
-        
+  async function getPageOfTasks(cursor) {
+    let request_payload = "";
+    // Create the request payload based on the presense of a start_cursor
+    if (cursor == undefined) {
+      request_payload = {
+        path: "databases/" + database_id + "/query",
+        method: "POST",
+      };
+    } else {
+      request_payload = {
+        path: "databases/" + database_id + "/query",
+        method: "POST",
+        body: {
+          start_cursor: cursor,
+        },
+      };
     }
-    await getPageOfTasks();
-    return tasks; 
-}; 
+    // While there are more pages left in the query, get pages from the database.
+    const current_pages = await notion.request(request_payload);
+
+    for (const page of current_pages.results) {
+      if (page.properties.Status) {
+        tasks[page.id] = {
+          Status: page.properties.Status.select.name,
+          Title: page.properties.Name.title[0].text.content,
+        };
+      } else {
+        tasks[page.id] = {
+          Status: "No Status",
+          Title: page.properties.Name.title[0].text.content,
+        };
+      }
+    }
+    if (current_pages.has_more) {
+      await getPageOfTasks(current_pages.next_cursor);
+    }
+  }
+  await getPageOfTasks();
+  return tasks;
+}

--- a/examples/database-update-send-email/index.js
+++ b/examples/database-update-send-email/index.js
@@ -1,120 +1,120 @@
 // Find the official Notion API client @ https:// github.com/makenotion/notion-sdk-js/
 // npm install @notionhq/client
-const { Client } = require("@notionhq/client");
+const { Client } = require("@notionhq/client")
 
-const dotenv = require("dotenv");
-dotenv.config();
+const dotenv = require("dotenv")
+dotenv.config()
 
-const sgMail = require("@sendgrid/mail");
-sgMail.setApiKey(process.env.SENDGRID_KEY);
+const sgMail = require("@sendgrid/mail")
+sgMail.setApiKey(process.env.SENDGRID_KEY)
 
-const notion = new Client({ auth: process.env.NOTION_KEY });
+const notion = new Client({ auth: process.env.NOTION_KEY })
 
-const database_id = process.env.NOTION_DATABASE_ID;
+const database_id = process.env.NOTION_DATABASE_ID
 
 // A JSON Object to hold all tasks in the Notion database
-let tasksInDatabase = {};
+let tasksInDatabase = {}
 
 async function findChangesAndSendEmails() {
-  console.log("Looking for changes in Notion database ");
-  // Get the tasks currently in the database
-  const currTasksInDatabase = await getTasksFromDatabase();
+	console.log("Looking for changes in Notion database ")
+	// Get the tasks currently in the database
+	const currTasksInDatabase = await getTasksFromDatabase()
 
-  // Iterate over the current tasks and compare them to tasks in our local store (tasksInDatabase)
-  for (const [key, value] of Object.entries(currTasksInDatabase)) {
-    const page_id = key;
-    const curr_status = value.Status;
-    // If this task hasn't been seen before
-    if (!page_id in tasksInDatabase) {
-      // Add this task to the local store of all tasks
-      tasksInDatabase[page_id] = {
-        Status: curr_status,
-      };
-    } else {
-      // If the current status is different from the status in the local store
-      if (curr_status !== tasksInDatabase[page_id].Status) {
-        // Change the local store.
-        tasksInDatabase[page_id] = {
-          Status: curr_status,
-        };
-        // Send an email about this change.
-        const msg = {
-          to: process.env.EMAIL_TO_FIELD,
-          from: process.env.EMAIL_FROM_FIELD,
-          subject: "Notion Task Status Updated",
-          text:
-            "A Notion task's: " +
-            value.Title +
-            " status has been updated to " +
-            curr_status +
-            ".",
-        };
-        sgMail
-          .send(msg)
-          .then(() => {
-            console.log("Email Sent");
-          })
-          .catch((error) => {
-            console.error(error);
-          });
-        console.log("Status Changed");
-      }
-    }
-  }
-  // Run this method every 5 seconds (5000 milliseconds)
-  setTimeout(main, 5000);
+	// Iterate over the current tasks and compare them to tasks in our local store (tasksInDatabase)
+	for (const [key, value] of Object.entries(currTasksInDatabase)) {
+		const page_id = key
+		const curr_status = value.Status
+		// If this task hasn't been seen before
+		if (!page_id in tasksInDatabase) {
+			// Add this task to the local store of all tasks
+			tasksInDatabase[page_id] = {
+				Status: curr_status,
+			}
+		} else {
+			// If the current status is different from the status in the local store
+			if (curr_status !== tasksInDatabase[page_id].Status) {
+				// Change the local store.
+				tasksInDatabase[page_id] = {
+					Status: curr_status,
+				}
+				// Send an email about this change.
+				const msg = {
+					to: process.env.EMAIL_TO_FIELD,
+					from: process.env.EMAIL_FROM_FIELD,
+					subject: "Notion Task Status Updated",
+					text:
+						"A Notion task's: " +
+						value.Title +
+						" status has been updated to " +
+						curr_status +
+						".",
+				}
+				sgMail
+					.send(msg)
+					.then(() => {
+						console.log("Email Sent")
+					})
+					.catch(error => {
+						console.error(error)
+					})
+				console.log("Status Changed")
+			}
+		}
+	}
+	// Run this method every 5 seconds (5000 milliseconds)
+	setTimeout(main, 5000)
 }
 
 function main() {
-  findChangesAndSendEmails().catch(console.error);
+	findChangesAndSendEmails().catch(console.error)
 }
 
-(async () => {
-  tasksInDatabase = await getTasksFromDatabase();
-  main();
-})();
+;(async () => {
+	tasksInDatabase = await getTasksFromDatabase()
+	main()
+})()
 
 // Get a paginated list of Tasks currently in a the database.
 async function getTasksFromDatabase() {
-  const tasks = {};
+	const tasks = {}
 
-  async function getPageOfTasks(cursor) {
-    let request_payload = "";
-    // Create the request payload based on the presense of a start_cursor
-    if (cursor == undefined) {
-      request_payload = {
-        path: "databases/" + database_id + "/query",
-        method: "POST",
-      };
-    } else {
-      request_payload = {
-        path: "databases/" + database_id + "/query",
-        method: "POST",
-        body: {
-          start_cursor: cursor,
-        },
-      };
-    }
-    // While there are more pages left in the query, get pages from the database.
-    const current_pages = await notion.request(request_payload);
+	async function getPageOfTasks(cursor) {
+		let request_payload = ""
+		// Create the request payload based on the presense of a start_cursor
+		if (cursor == undefined) {
+			request_payload = {
+				path: "databases/" + database_id + "/query",
+				method: "POST",
+			}
+		} else {
+			request_payload = {
+				path: "databases/" + database_id + "/query",
+				method: "POST",
+				body: {
+					start_cursor: cursor,
+				},
+			}
+		}
+		// While there are more pages left in the query, get pages from the database.
+		const current_pages = await notion.request(request_payload)
 
-    for (const page of current_pages.results) {
-      if (page.properties.Status) {
-        tasks[page.id] = {
-          Status: page.properties.Status.select.name,
-          Title: page.properties.Name.title[0].text.content,
-        };
-      } else {
-        tasks[page.id] = {
-          Status: "No Status",
-          Title: page.properties.Name.title[0].text.content,
-        };
-      }
-    }
-    if (current_pages.has_more) {
-      await getPageOfTasks(current_pages.next_cursor);
-    }
-  }
-  await getPageOfTasks();
-  return tasks;
+		for (const page of current_pages.results) {
+			if (page.properties.Status) {
+				tasks[page.id] = {
+					Status: page.properties.Status.select.name,
+					Title: page.properties.Name.title[0].text.content,
+				}
+			} else {
+				tasks[page.id] = {
+					Status: "No Status",
+					Title: page.properties.Name.title[0].text.content,
+				}
+			}
+		}
+		if (current_pages.has_more) {
+			await getPageOfTasks(current_pages.next_cursor)
+		}
+	}
+	await getPageOfTasks()
+	return tasks
 }

--- a/examples/database-update-send-email/package.json
+++ b/examples/database-update-send-email/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "database-update-send-email",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "dependencies": {
-    "@notionhq/client": "latest",
-    "@sendgrid/mail": "^7.4.2",
-    "dotenv": "^8.2.0"
-  },
-  "devDependencies": {},
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "Aman Gupta",
-  "license": "MIT"
+	"name": "database-update-send-email",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"dependencies": {
+		"@notionhq/client": "latest",
+		"@sendgrid/mail": "^7.4.2",
+		"dotenv": "^8.2.0"
+	},
+	"devDependencies": {},
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"author": "Aman Gupta",
+	"license": "MIT"
 }

--- a/examples/github-issue-sync/README.md
+++ b/examples/github-issue-sync/README.md
@@ -1,26 +1,28 @@
 # Sample Integration: GitHub Issues to Notion
 
-<img src="https://dev.notion.so/front-static/external/readme/images/github-notion-example@2x.png" alt="drawing" width="500"/> 
+<img src="https://dev.notion.so/front-static/external/readme/images/github-notion-example@2x.png" alt="drawing" width="500"/>
 
-## About the Integration 
+## About the Integration
 
 This Notion integration syncs GitHub Issues for a specific repo to a Notion Database. This integration was built using this [database template](https://www.notion.so/367cd67cfe8f49bfaf0ac21305ebb9bf?v=bc79ca62b36e4c54b655ceed4ef06ebd) and [GitHub's Octokit Library](https://github.com/octokit). Changes made to issues in the Notion database will not be reflected in GitHub. For an example which allows you to take actions based on changes in a database [go here.](https://github.com/makenotion/notion-sdk-js/examples/database-update-send-email)
 
 ## Running Locally
 
 ### 1. Setup your local project
+
 ```zsh
-# Clone this repository locally 
-git clone https://github.com/makenotion/notion-sdk-js.git 
+# Clone this repository locally
+git clone https://github.com/makenotion/notion-sdk-js.git
 
 # Switch into this project
 cd notion-sdk-js/examples/github-issue-sync
 
-# Install the dependencies 
+# Install the dependencies
 npm install
 ```
 
 ### 2. Set your enviornment variables in a `.env` file
+
 ```zsh
 GITHUB_KEY=<your-github-personal-access-token>
 NOTION_KEY=<your-notion-api-key>
@@ -35,7 +37,7 @@ You can create your GitHub Personal Access token by following the guide [here](h
 
 To create a Notion database that will work with this example, duplicate [this empty database template](https://www.notion.so/367cd67cfe8f49bfaf0ac21305ebb9bf?v=bc79ca62b36e4c54b655ceed4ef06ebd).
 
-### 3. Run code 
+### 3. Run code
 
 ```zsh
 node index.js

--- a/examples/github-issue-sync/index.js
+++ b/examples/github-issue-sync/index.js
@@ -1,115 +1,117 @@
-const {Octokit} = require("octokit")
-const dotenv = require("dotenv")
-const {Client} = require("@notionhq/client");
+// Find the official Notion API client @ https:// github.com/makenotion/notion-sdk-js/
+// npm install @notionhq/client
+const { Client } = require("@notionhq/client");
+
+const { Octokit } = require("octokit");
+
+const dotenv = require("dotenv");
 dotenv.config();
 
-const octokit = new Octokit({auth: process.env.GITHUB_KEY})
-const notion = new Client({auth:process.env.NOTION_KEY}); 
+const octokit = new Octokit({ auth: process.env.GITHUB_KEY });
+const notion = new Client({ auth: process.env.NOTION_KEY });
 
 const database_id = process.env.NOTION_DATABASE_ID;
 
-async function syncIssuesWithDatabase(){
-    console.log("Syncing GitHub Issues with Notion Database")
-    const issuesInDatabase = await getIssuesFromDatabse(); 
+async function syncIssuesWithDatabase() {
+  console.log("Syncing GitHub Issues with Notion Database");
+  const issuesInDatabase = await getIssuesFromDatabse();
 
-    //Get a list of github issues and add them to a local store
-    let gitHubIssues = {}; 
-    const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
-        owner: process.env.GITHUB_REPO_OWNER,
-        repo:process.env.GITHUB_REPO_NAME, 
-        per_page: 100
-    }); 
+  // Get a list of github issues and add them to a local store
+  let gitHubIssues = {};
+  const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
+    owner: process.env.GITHUB_REPO_OWNER,
+    repo: process.env.GITHUB_REPO_NAME,
+    per_page: 100,
+  });
 
-    for await (const {data: issues} of iterator) {
-        for (const issue of issues) {
-            gitHubIssues[issue.number] = {
-                "id": issue.id, 
-                "title": issue.title, 
-                "state": issue.state,
-                "comments": issue.comments, 
-            }
-        }
+  for await (const { data: issues } of iterator) {
+    for (const issue of issues) {
+      gitHubIssues[issue.number] = {
+        id: issue.id,
+        title: issue.title,
+        state: issue.state,
+        comments: issue.comments,
+      };
     }
+  }
 
-    //Create new issues or update existing in a Notion Database
-    for (const [key,value] of Object.entries(gitHubIssues)){
-        const issue_number = key 
-        const issues_details = value
-        //If the issue does not exist in the database yet, add it to the database
-        if(!(issue_number in issuesInDatabase)){
-            await notion.request({
-                path:'pages', 
-                method:"POST", 
-                body:{
-                    "parent": { "database_id": database_id},
-                    "properties": {
-                        "State": {"name": issues_details.state},
-                        "Issue Number": parseInt(issue_number),
-                        "Name": [ { "text": {"content" : issues_details.title} } ],
-                        "Comments": parseInt(issues_details.comments)
-                    }
-                }
-            })
-        } else 
-        //This issue already exists in the database so we want to update the page
-        {
-            await notion.request({
-                path:'pages/'+issuesInDatabase[issue_number].page_id,
-                method:'patch', 
-                body:{
-                    "properties": {
-                        "State": {"name": issues_details.state},
-                        "Issue Number": parseInt(issue_number),
-                        "Name": [ { "text": {"content" : issues_details.title} } ],
-                        "Comments": parseInt(issues_details.comments) 
-                    }
-                }
-            })
-        }
+  // Create new issues or update existing in a Notion Database
+  for (const [key, value] of Object.entries(gitHubIssues)) {
+    const issue_number = key;
+    const issues_details = value;
+    // If the issue does not exist in the database yet, add it to the database
+    if (!(issue_number in issuesInDatabase)) {
+      await notion.request({
+        path: "pages",
+        method: "POST",
+        body: {
+          parent: { database_id: database_id },
+          properties: {
+            State: { name: issues_details.state },
+            "Issue Number": parseInt(issue_number),
+            Name: [{ text: { content: issues_details.title } }],
+            Comments: parseInt(issues_details.comments),
+          },
+        },
+      });
     }
-    //Run this function every five minutes
-    setTimeout(syncIssuesWithDatabase, 5*60*1000)
+    // This issue already exists in the database so we want to update the page
+    else {
+      await notion.request({
+        path: "pages/" + issuesInDatabase[issue_number].page_id,
+        method: "patch",
+        body: {
+          properties: {
+            State: { name: issues_details.state },
+            "Issue Number": parseInt(issue_number),
+            Name: [{ text: { content: issues_details.title } }],
+            Comments: parseInt(issues_details.comments),
+          },
+        },
+      });
+    }
+  }
+  // Run this function every five minutes
+  setTimeout(syncIssuesWithDatabase, 5 * 60 * 1000);
 }
 
 (async () => {
-    syncIssuesWithDatabase(); 
-})()
+  syncIssuesWithDatabase();
+})();
 
-//Get a paginated list of Tasks currently in a the database. 
+// Get a paginated list of Tasks currently in a the database.
 async function getIssuesFromDatabse() {
+  const issues = {};
 
-    const issues = {}; 
-
-    async function getPageOfIssues(cursor){
-        let request_payload = "";
-        //Create the request payload based on the presense of a start_cursor
-        if(cursor == undefined){
-            request_payload = {
-                path:'databases/' + database_id + '/query', 
-                method:'POST',
-            }
-        } else {
-            request_payload= {
-                path:'databases/' + database_id + '/query', 
-                method:'POST',
-                body:{
-                    "start_cursor": cursor
-                }
-            }
-        }
-        //While there are more pages left in the query, get pages from the database. 
-        const current_pages = await notion.request(request_payload)
-        
-        for(const page of current_pages.results){
-            issues[page.properties["Issue Number"].number] = {
-                "page_id": page.id, 
-            }
-        }
-        if(current_pages.has_more){
-            await getPageOfIssues(current_pages.next_cursor)
-        }
-        
+  async function getPageOfIssues(cursor) {
+    let request_payload = "";
+    // Create the request payload based on the presense of a start_cursor
+    if (cursor == undefined) {
+      request_payload = {
+        path: "databases/" + database_id + "/query",
+        method: "POST",
+      };
+    } else {
+      request_payload = {
+        path: "databases/" + database_id + "/query",
+        method: "POST",
+        body: {
+          start_cursor: cursor,
+        },
+      };
     }
-    await getPageOfIssues();
-    return issues; 
-}; 
+    // While there are more pages left in the query, get pages from the database.
+    const current_pages = await notion.request(request_payload);
+
+    for (const page of current_pages.results) {
+      issues[page.properties["Issue Number"].number] = {
+        page_id: page.id,
+      };
+    }
+    if (current_pages.has_more) {
+      await getPageOfIssues(current_pages.next_cursor);
+    }
+  }
+  await getPageOfIssues();
+  return issues;
+}

--- a/examples/github-issue-sync/index.js
+++ b/examples/github-issue-sync/index.js
@@ -1,117 +1,117 @@
 // Find the official Notion API client @ https:// github.com/makenotion/notion-sdk-js/
 // npm install @notionhq/client
-const { Client } = require("@notionhq/client");
+const { Client } = require("@notionhq/client")
 
-const { Octokit } = require("octokit");
+const { Octokit } = require("octokit")
 
-const dotenv = require("dotenv");
-dotenv.config();
+const dotenv = require("dotenv")
+dotenv.config()
 
-const octokit = new Octokit({ auth: process.env.GITHUB_KEY });
-const notion = new Client({ auth: process.env.NOTION_KEY });
+const octokit = new Octokit({ auth: process.env.GITHUB_KEY })
+const notion = new Client({ auth: process.env.NOTION_KEY })
 
-const database_id = process.env.NOTION_DATABASE_ID;
+const database_id = process.env.NOTION_DATABASE_ID
 
 async function syncIssuesWithDatabase() {
-  console.log("Syncing GitHub Issues with Notion Database");
-  const issuesInDatabase = await getIssuesFromDatabse();
+	console.log("Syncing GitHub Issues with Notion Database")
+	const issuesInDatabase = await getIssuesFromDatabse()
 
-  // Get a list of github issues and add them to a local store
-  let gitHubIssues = {};
-  const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
-    owner: process.env.GITHUB_REPO_OWNER,
-    repo: process.env.GITHUB_REPO_NAME,
-    per_page: 100,
-  });
+	// Get a list of github issues and add them to a local store
+	let gitHubIssues = {}
+	const iterator = octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
+		owner: process.env.GITHUB_REPO_OWNER,
+		repo: process.env.GITHUB_REPO_NAME,
+		per_page: 100,
+	})
 
-  for await (const { data: issues } of iterator) {
-    for (const issue of issues) {
-      gitHubIssues[issue.number] = {
-        id: issue.id,
-        title: issue.title,
-        state: issue.state,
-        comments: issue.comments,
-      };
-    }
-  }
+	for await (const { data: issues } of iterator) {
+		for (const issue of issues) {
+			gitHubIssues[issue.number] = {
+				id: issue.id,
+				title: issue.title,
+				state: issue.state,
+				comments: issue.comments,
+			}
+		}
+	}
 
-  // Create new issues or update existing in a Notion Database
-  for (const [key, value] of Object.entries(gitHubIssues)) {
-    const issue_number = key;
-    const issues_details = value;
-    // If the issue does not exist in the database yet, add it to the database
-    if (!(issue_number in issuesInDatabase)) {
-      await notion.request({
-        path: "pages",
-        method: "POST",
-        body: {
-          parent: { database_id: database_id },
-          properties: {
-            State: { name: issues_details.state },
-            "Issue Number": parseInt(issue_number),
-            Name: [{ text: { content: issues_details.title } }],
-            Comments: parseInt(issues_details.comments),
-          },
-        },
-      });
-    }
-    // This issue already exists in the database so we want to update the page
-    else {
-      await notion.request({
-        path: "pages/" + issuesInDatabase[issue_number].page_id,
-        method: "patch",
-        body: {
-          properties: {
-            State: { name: issues_details.state },
-            "Issue Number": parseInt(issue_number),
-            Name: [{ text: { content: issues_details.title } }],
-            Comments: parseInt(issues_details.comments),
-          },
-        },
-      });
-    }
-  }
-  // Run this function every five minutes
-  setTimeout(syncIssuesWithDatabase, 5 * 60 * 1000);
+	// Create new issues or update existing in a Notion Database
+	for (const [key, value] of Object.entries(gitHubIssues)) {
+		const issue_number = key
+		const issues_details = value
+		// If the issue does not exist in the database yet, add it to the database
+		if (!(issue_number in issuesInDatabase)) {
+			await notion.request({
+				path: "pages",
+				method: "POST",
+				body: {
+					parent: { database_id: database_id },
+					properties: {
+						State: { name: issues_details.state },
+						"Issue Number": parseInt(issue_number),
+						Name: [{ text: { content: issues_details.title } }],
+						Comments: parseInt(issues_details.comments),
+					},
+				},
+			})
+		}
+		// This issue already exists in the database so we want to update the page
+		else {
+			await notion.request({
+				path: "pages/" + issuesInDatabase[issue_number].page_id,
+				method: "patch",
+				body: {
+					properties: {
+						State: { name: issues_details.state },
+						"Issue Number": parseInt(issue_number),
+						Name: [{ text: { content: issues_details.title } }],
+						Comments: parseInt(issues_details.comments),
+					},
+				},
+			})
+		}
+	}
+	// Run this function every five minutes
+	setTimeout(syncIssuesWithDatabase, 5 * 60 * 1000)
 }
 
-(async () => {
-  syncIssuesWithDatabase();
-})();
+;(async () => {
+	syncIssuesWithDatabase()
+})()
 
 // Get a paginated list of Tasks currently in a the database.
 async function getIssuesFromDatabse() {
-  const issues = {};
+	const issues = {}
 
-  async function getPageOfIssues(cursor) {
-    let request_payload = "";
-    // Create the request payload based on the presense of a start_cursor
-    if (cursor == undefined) {
-      request_payload = {
-        path: "databases/" + database_id + "/query",
-        method: "POST",
-      };
-    } else {
-      request_payload = {
-        path: "databases/" + database_id + "/query",
-        method: "POST",
-        body: {
-          start_cursor: cursor,
-        },
-      };
-    }
-    // While there are more pages left in the query, get pages from the database.
-    const current_pages = await notion.request(request_payload);
+	async function getPageOfIssues(cursor) {
+		let request_payload = ""
+		// Create the request payload based on the presense of a start_cursor
+		if (cursor == undefined) {
+			request_payload = {
+				path: "databases/" + database_id + "/query",
+				method: "POST",
+			}
+		} else {
+			request_payload = {
+				path: "databases/" + database_id + "/query",
+				method: "POST",
+				body: {
+					start_cursor: cursor,
+				},
+			}
+		}
+		// While there are more pages left in the query, get pages from the database.
+		const current_pages = await notion.request(request_payload)
 
-    for (const page of current_pages.results) {
-      issues[page.properties["Issue Number"].number] = {
-        page_id: page.id,
-      };
-    }
-    if (current_pages.has_more) {
-      await getPageOfIssues(current_pages.next_cursor);
-    }
-  }
-  await getPageOfIssues();
-  return issues;
+		for (const page of current_pages.results) {
+			issues[page.properties["Issue Number"].number] = {
+				page_id: page.id,
+			}
+		}
+		if (current_pages.has_more) {
+			await getPageOfIssues(current_pages.next_cursor)
+		}
+	}
+	await getPageOfIssues()
+	return issues
 }

--- a/examples/github-issue-sync/package.json
+++ b/examples/github-issue-sync/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "github-issue-sync",
-  "version": "1.0.0",
-  "description": "**TODO**",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "Aman Gupta",
-  "license": "MIT",
-  "dependencies": {
-    "dotenv": "^8.2.0",
-    "octokit": "^1.0.3",
-    "@notionhq/client": "latest"
-  }
+	"name": "github-issue-sync",
+	"version": "1.0.0",
+	"description": "**TODO**",
+	"main": "index.js",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"author": "Aman Gupta",
+	"license": "MIT",
+	"dependencies": {
+		"dotenv": "^8.2.0",
+		"octokit": "^1.0.3",
+		"@notionhq/client": "latest"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,39 @@
 {
-  "name": "@notionhq/client",
-  "version": "0.1.3",
-  "description": "A simple and easy to use client for the Notion API",
-  "engines": {
-    "node": ">=14.15.0"
-  },
-  "keywords": ["notion", "notionapi", "rest", "notion-api"],
-  "main": "./build/src",
-  "scripts": {
-    "prepare": "npm run build",
-    "build": "tsc",
-    "lint": "eslint . --ext .ts",
-    "test": "ava"
-  },
-  "author": "",
-  "license": "MIT",
-  "files": ["build/src/**"],
-  "dependencies": {
-    "got": "^11.8.2"
-  },
-  "devDependencies": {
-    "@ava/typescript": "^2.0.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
-    "ava": "^3.15.0",
-    "eslint": "^7.24.0",
-    "typescript": "^4.2.4"
-  }
+	"name": "@notionhq/client",
+	"version": "0.1.3",
+	"description": "A simple and easy to use client for the Notion API",
+	"engines": {
+		"node": ">=12.21.0"
+	},
+	"keywords": [
+		"notion",
+		"notionapi",
+		"rest",
+		"notion-api"
+	],
+	"main": "./build/src",
+	"scripts": {
+		"prepare": "npm run build",
+		"build": "tsc",
+		"lint": "eslint . --ext .ts",
+		"test": "ava",
+		"format": "prettier --write ."
+	},
+	"author": "",
+	"license": "MIT",
+	"files": [
+		"build/src/**"
+	],
+	"dependencies": {
+		"got": "^11.8.2"
+	},
+	"devDependencies": {
+		"prettier": "^2.3.0",
+		"@ava/typescript": "^2.0.0",
+		"@typescript-eslint/eslint-plugin": "^4.22.0",
+		"@typescript-eslint/parser": "^4.22.0",
+		"ava": "^3.15.0",
+		"eslint": "^7.24.0",
+		"typescript": "^4.2.4"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,15 @@
 		"got": "^11.8.2"
 	},
 	"devDependencies": {
-		"prettier": "^2.3.0",
 		"@ava/typescript": "^2.0.0",
 		"@typescript-eslint/eslint-plugin": "^4.22.0",
 		"@typescript-eslint/parser": "^4.22.0",
 		"ava": "^3.15.0",
 		"eslint": "^7.24.0",
+		"eslint-plugin-formatjs": "2.12.1",
+		"eslint-plugin-import": "2.22.1",
+		"eslint-plugin-unused-imports": "1.1.0",
+		"prettier": "^2.3.0",
 		"typescript": "^4.2.4"
 	}
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,334 +1,401 @@
-import type { Agent } from 'http';
-import { URL } from 'url';
-import { Logger, LogLevel, logLevelSeverity, makeConsoleLogger } from './logging';
-import { buildRequestError, HTTPResponseError } from './errors'
-import { pick } from './helpers';
+import type { Agent } from "http"
+import { URL } from "url"
 import {
-  BlocksChildrenAppendParameters, BlocksChildrenAppendResponse, blocksChildrenAppend,
-  BlocksChildrenListParameters, BlocksChildrenListResponse, blocksChildrenList,
-  DatabasesListParameters, DatabasesListResponse, databasesList,
-  DatabasesQueryResponse, DatabasesQueryParameters, databasesQuery,
-  DatabasesRetrieveParameters, DatabasesRetrieveResponse, databasesRetrieve,
-  PagesCreateParameters, PagesCreateResponse, pagesCreate,
-  PagesRetrieveParameters, PagesRetrieveResponse, pagesRetrieve,
-  PagesUpdateParameters, PagesUpdateResponse, pagesUpdate,
-  UsersListParameters, UsersListResponse, usersList,
-  UsersRetrieveParameters, UsersRetrieveResponse, usersRetrieve,
-  SearchParameters, SearchResponse, search,
-} from './api-endpoints';
+	Logger,
+	LogLevel,
+	logLevelSeverity,
+	makeConsoleLogger,
+} from "./logging"
+import { buildRequestError, HTTPResponseError } from "./errors"
+import { pick } from "./helpers"
+import {
+	BlocksChildrenAppendParameters,
+	BlocksChildrenAppendResponse,
+	blocksChildrenAppend,
+	BlocksChildrenListParameters,
+	BlocksChildrenListResponse,
+	blocksChildrenList,
+	DatabasesListParameters,
+	DatabasesListResponse,
+	databasesList,
+	DatabasesQueryResponse,
+	DatabasesQueryParameters,
+	databasesQuery,
+	DatabasesRetrieveParameters,
+	DatabasesRetrieveResponse,
+	databasesRetrieve,
+	PagesCreateParameters,
+	PagesCreateResponse,
+	pagesCreate,
+	PagesRetrieveParameters,
+	PagesRetrieveResponse,
+	pagesRetrieve,
+	PagesUpdateParameters,
+	PagesUpdateResponse,
+	pagesUpdate,
+	UsersListParameters,
+	UsersListResponse,
+	usersList,
+	UsersRetrieveParameters,
+	UsersRetrieveResponse,
+	usersRetrieve,
+	SearchParameters,
+	SearchResponse,
+	search,
+} from "./api-endpoints"
 
-import got, { Got, Options as GotOptions, Headers as GotHeaders, Agents as GotAgents } from 'got';
+import got, {
+	Got,
+	Options as GotOptions,
+	Headers as GotHeaders,
+	Agents as GotAgents,
+} from "got"
 
 export interface ClientOptions {
-  auth?: string;
-  timeoutMs?: number;
-  baseUrl?: string;
-  logLevel?: LogLevel;
-  logger?: Logger;
-  agent?: Agent;
-  notionVersion?: string;
+	auth?: string
+	timeoutMs?: number
+	baseUrl?: string
+	logLevel?: LogLevel
+	logger?: Logger
+	agent?: Agent
+	notionVersion?: string
 }
 
 export interface RequestParameters {
-  path: string;
-  method: Method;
-  query?: QueryParams;
-  body?: Record<string, unknown>;
-  auth?: string;
+	path: string
+	method: Method
+	query?: QueryParams
+	body?: Record<string, unknown>
+	auth?: string
 }
 
 export default class Client {
+	#auth?: string
+	#logLevel: LogLevel
+	#logger: Logger
+	#got: Got
 
-  #auth?: string;
-  #logLevel: LogLevel;
-  #logger: Logger;
-  #got: Got;
+	static readonly defaultNotionVersion = "2021-05-13"
 
-  static readonly defaultNotionVersion = '2021-05-13';
+	public constructor(options?: ClientOptions) {
+		this.#auth = options?.auth
+		this.#logLevel = options?.logLevel ?? LogLevel.WARN
+		this.#logger = options?.logger ?? makeConsoleLogger(this.constructor.name)
 
-  public constructor(options?: ClientOptions) {
-    this.#auth = options?.auth;
-    this.#logLevel = options?.logLevel ?? LogLevel.WARN;
-    this.#logger = options?.logger ?? makeConsoleLogger(this.constructor.name);
+		const prefixUrl = (options?.baseUrl ?? "https://api.notion.com") + "/v1/"
+		const timeout = options?.timeoutMs ?? 60_000
+		const notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
 
-    const prefixUrl = (options?.baseUrl ?? 'https://api.notion.com') + '/v1/';
-    const timeout = options?.timeoutMs ?? 60_000;
-    const notionVersion = options?.notionVersion ?? Client.defaultNotionVersion;
+		this.#got = got.extend({
+			prefixUrl,
+			timeout,
+			headers: {
+				"Notion-Version": notionVersion,
+				// TODO: update with format appropriate for telemetry, use version from package.json
+				"user-agent": "notionhq-client/0.1.0",
+			},
+			retry: 0,
+			agent: makeAgentOption(prefixUrl, options?.agent),
+		})
+	}
 
-    this.#got = got.extend({
-      prefixUrl,
-      timeout,
-      headers: {
-        'Notion-Version': notionVersion,
-        // TODO: update with format appropriate for telemetry, use version from package.json
-        'user-agent': 'notionhq-client/0.1.0',
-      },
-      retry: 0,
-      agent: makeAgentOption(prefixUrl, options?.agent),
-    });
-  }
+	/**
+	 * Sends a request.
+	 *
+	 * @param path
+	 * @param method
+	 * @param query
+	 * @param body
+	 * @returns
+	 */
+	public async request<Response>({
+		path,
+		method,
+		query,
+		body,
+		auth,
+	}: RequestParameters): Promise<Response> {
+		this.log(LogLevel.INFO, "request start", { method, path })
 
-  /**
-   * Sends a request.
-   *
-   * @param path
-   * @param method
-   * @param query
-   * @param body
-   * @returns
-   */
-  public async request<Response>({ path, method, query, body, auth }: RequestParameters): Promise<Response> {
-    this.log(LogLevel.INFO, 'request start', { method, path });
+		// If the body is empty, don't send the body in the HTTP request
+		const json =
+			body !== undefined && Object.entries(body).length === 0 ? undefined : body
 
-    // If the body is empty, don't send the body in the HTTP request
-    const json = (body !== undefined && Object.entries(body).length === 0) ? undefined : body;
+		try {
+			const response = await this.#got(path, {
+				method,
+				searchParams: query,
+				json,
+				headers: this.authAsHeaders(auth),
+			}).json<Response>()
 
-    try {
-      const response = await this.#got(path, {
-        method,
-        searchParams: query,
-        json,
-        headers: this.authAsHeaders(auth),
-      }).json<Response>();
+			this.log(LogLevel.INFO, `request success`, { method, path })
+			return response
+		} catch (error) {
+			// Build an error of a known type, otherwise throw unexpected errors
+			const requestError = buildRequestError(error)
+			if (requestError === undefined) {
+				throw error
+			}
 
-      this.log(LogLevel.INFO, `request success`, { method, path });
-      return response;
-    } catch (error) {
-      // Build an error of a known type, otherwise throw unexpected errors
-      const requestError = buildRequestError(error);
-      if (requestError === undefined) {
-        throw error;
-      }
+			this.log(LogLevel.WARN, `request fail`, {
+				code: requestError.code,
+				message: requestError.message,
+			})
+			if (HTTPResponseError.isHTTPResponseError(requestError)) {
+				// The response body may contain sensitive information so it is logged separately at the DEBUG level
+				this.log(LogLevel.DEBUG, `failed response body`, {
+					body: requestError.body,
+				})
+			}
 
-      this.log(LogLevel.WARN, `request fail`, { code: requestError.code, message: requestError.message });
-      if (HTTPResponseError.isHTTPResponseError(requestError)) {
-        // The response body may contain sensitive information so it is logged separately at the DEBUG level
-        this.log(LogLevel.DEBUG, `failed response body`, { body: requestError.body });
-      }
+			// Throw as a known error type
+			throw requestError
+		}
+	}
 
-      // Throw as a known error type
-      throw requestError;
-    }
-  }
+	/*
+	 * Notion API endpoints
+	 */
 
-  /*
-   * Notion API endpoints
-   */
+	public readonly blocks = {
+		children: {
+			/**
+			 * Append block children
+			 */
+			append: (
+				args: WithAuth<BlocksChildrenAppendParameters>
+			): Promise<BlocksChildrenAppendResponse> => {
+				return this.request<BlocksChildrenAppendResponse>({
+					path: blocksChildrenAppend.path(args),
+					method: blocksChildrenAppend.method,
+					query: pick(args, blocksChildrenAppend.queryParams),
+					body: pick(args, blocksChildrenAppend.bodyParams),
+					auth: args?.auth,
+				})
+			},
 
-  public readonly blocks = {
-    children: {
-      /**
-       * Append block children
-       */
-      append: (args: WithAuth<BlocksChildrenAppendParameters>): Promise<BlocksChildrenAppendResponse> => {
-        return this.request<BlocksChildrenAppendResponse>({
-          path: blocksChildrenAppend.path(args),
-          method: blocksChildrenAppend.method,
-          query: pick(args, blocksChildrenAppend.queryParams),
-          body: pick(args, blocksChildrenAppend.bodyParams),
-          auth: args?.auth,
-        });
-      },
+			/**
+			 * Retrieve block children
+			 */
+			list: (
+				args: WithAuth<BlocksChildrenListParameters>
+			): Promise<BlocksChildrenListResponse> => {
+				return this.request<BlocksChildrenListResponse>({
+					path: blocksChildrenList.path(args),
+					method: blocksChildrenList.method,
+					query: pick(args, blocksChildrenList.queryParams),
+					body: pick(args, blocksChildrenList.bodyParams),
+					auth: args?.auth,
+				})
+			},
+		},
+	}
 
-      /**
-       * Retrieve block children
-       */
-      list: (args: WithAuth<BlocksChildrenListParameters>): Promise<BlocksChildrenListResponse> => {
-        return this.request<BlocksChildrenListResponse>({
-          path: blocksChildrenList.path(args),
-          method: blocksChildrenList.method,
-          query: pick(args, blocksChildrenList.queryParams),
-          body: pick(args, blocksChildrenList.bodyParams),
-          auth: args?.auth,
-        });
-      },
-    }
-  }
+	public readonly databases = {
+		/**
+		 * List databases
+		 */
+		list: (
+			args: WithAuth<DatabasesListParameters>
+		): Promise<DatabasesListResponse> => {
+			return this.request<DatabasesListResponse>({
+				path: databasesList.path(),
+				method: databasesList.method,
+				query: pick(args, databasesList.queryParams),
+				body: pick(args, databasesList.bodyParams),
+				auth: args?.auth,
+			})
+		},
 
-  public readonly databases = {
-    /**
-     * List databases
-     */
-    list: (args: WithAuth<DatabasesListParameters>): Promise<DatabasesListResponse> => {
-      return this.request<DatabasesListResponse>({
-        path: databasesList.path(),
-        method: databasesList.method,
-        query: pick(args, databasesList.queryParams),
-        body: pick(args, databasesList.bodyParams),
-        auth: args?.auth,
-      });
-    },
+		/**
+		 * Retrieve a database
+		 */
+		retrieve: (
+			args: WithAuth<DatabasesRetrieveParameters>
+		): Promise<DatabasesRetrieveResponse> => {
+			return this.request<DatabasesRetrieveResponse>({
+				path: databasesRetrieve.path(args),
+				method: databasesRetrieve.method,
+				query: pick(args, databasesRetrieve.queryParams),
+				body: pick(args, databasesRetrieve.bodyParams),
+				auth: args?.auth,
+			})
+		},
 
-    /**
-     * Retrieve a database
-     */
-    retrieve: (args: WithAuth<DatabasesRetrieveParameters>): Promise<DatabasesRetrieveResponse> => {
-      return this.request<DatabasesRetrieveResponse>({
-        path: databasesRetrieve.path(args),
-        method: databasesRetrieve.method,
-        query: pick(args, databasesRetrieve.queryParams),
-        body: pick(args, databasesRetrieve.bodyParams),
-        auth: args?.auth,
-      });
-    },
+		/**
+		 * Query a database
+		 */
+		query: (
+			args: WithAuth<DatabasesQueryParameters>
+		): Promise<DatabasesQueryResponse> => {
+			return this.request<DatabasesQueryResponse>({
+				path: databasesQuery.path(args),
+				method: databasesQuery.method,
+				query: pick(args, databasesQuery.queryParams),
+				body: pick(args, databasesQuery.bodyParams),
+				auth: args?.auth,
+			})
+		},
+	}
 
-    /**
-     * Query a database
-     */
-    query: (args: WithAuth<DatabasesQueryParameters>): Promise<DatabasesQueryResponse> => {
-      return this.request<DatabasesQueryResponse>({
-        path: databasesQuery.path(args),
-        method: databasesQuery.method,
-        query: pick(args, databasesQuery.queryParams),
-        body: pick(args, databasesQuery.bodyParams),
-        auth: args?.auth,
-      });
-    },
-  };
+	public readonly pages = {
+		/**
+		 * Create a page
+		 */
+		create: (
+			args: WithAuth<PagesCreateParameters>
+		): Promise<PagesCreateResponse> => {
+			return this.request<PagesCreateResponse>({
+				path: pagesCreate.path(),
+				method: pagesCreate.method,
+				query: pick(args, pagesCreate.queryParams),
+				body: pick(args, pagesCreate.bodyParams),
+				auth: args?.auth,
+			})
+		},
 
-  public readonly pages = {
-    /**
-     * Create a page
-     */
-    create: (args: WithAuth<PagesCreateParameters>): Promise<PagesCreateResponse> => {
-      return this.request<PagesCreateResponse>({
-        path: pagesCreate.path(),
-        method: pagesCreate.method,
-        query: pick(args, pagesCreate.queryParams),
-        body: pick(args, pagesCreate.bodyParams),
-        auth: args?.auth,
-      });
-    },
+		/**
+		 * Retrieve a page
+		 */
+		retrieve: (
+			args: WithAuth<PagesRetrieveParameters>
+		): Promise<PagesRetrieveResponse> => {
+			return this.request<PagesRetrieveResponse>({
+				path: pagesRetrieve.path(args),
+				method: pagesRetrieve.method,
+				query: pick(args, pagesRetrieve.queryParams),
+				body: pick(args, pagesRetrieve.bodyParams),
+				auth: args?.auth,
+			})
+		},
 
-    /**
-     * Retrieve a page
-     */
-    retrieve: (args: WithAuth<PagesRetrieveParameters>): Promise<PagesRetrieveResponse> => {
-      return this.request<PagesRetrieveResponse>({
-        path: pagesRetrieve.path(args),
-        method: pagesRetrieve.method,
-        query: pick(args, pagesRetrieve.queryParams),
-        body: pick(args, pagesRetrieve.bodyParams),
-        auth: args?.auth,
-      });
-    },
+		/**
+		 * Update page properties
+		 */
+		update: (
+			args: WithAuth<PagesUpdateParameters>
+		): Promise<PagesUpdateResponse> => {
+			return this.request<PagesUpdateResponse>({
+				path: pagesUpdate.path(args),
+				method: pagesUpdate.method,
+				query: pick(args, pagesUpdate.queryParams),
+				body: pick(args, pagesUpdate.bodyParams),
+				auth: args?.auth,
+			})
+		},
+	}
 
-    /**
-     * Update page properties
-     */
-    update: (args: WithAuth<PagesUpdateParameters>): Promise<PagesUpdateResponse> => {
-      return this.request<PagesUpdateResponse>({
-        path: pagesUpdate.path(args),
-        method: pagesUpdate.method,
-        query: pick(args, pagesUpdate.queryParams),
-        body: pick(args, pagesUpdate.bodyParams),
-        auth: args?.auth,
-      });
-    },
-  };
+	public readonly users = {
+		/**
+		 * Retrieve a user
+		 */
+		retrieve: (
+			args: WithAuth<UsersRetrieveParameters>
+		): Promise<UsersRetrieveResponse> => {
+			return this.request<UsersRetrieveResponse>({
+				path: usersRetrieve.path(args),
+				method: usersRetrieve.method,
+				query: pick(args, usersRetrieve.queryParams),
+				body: pick(args, usersRetrieve.bodyParams),
+				auth: args?.auth,
+			})
+		},
 
-  public readonly users = {
-    /**
-     * Retrieve a user
-     */
-    retrieve: (args: WithAuth<UsersRetrieveParameters>): Promise<UsersRetrieveResponse> => {
-      return this.request<UsersRetrieveResponse>({
-        path: usersRetrieve.path(args),
-        method: usersRetrieve.method,
-        query: pick(args, usersRetrieve.queryParams),
-        body: pick(args, usersRetrieve.bodyParams),
-        auth: args?.auth,
-      });
-    },
+		/**
+		 * List all users
+		 */
+		list: (args: WithAuth<UsersListParameters>): Promise<UsersListResponse> => {
+			return this.request<UsersListResponse>({
+				path: usersList.path(),
+				method: usersList.method,
+				query: pick(args, usersList.queryParams),
+				body: pick(args, usersList.bodyParams),
+				auth: args?.auth,
+			})
+		},
+	}
 
-    /**
-     * List all users
-     */
-    list: (args: WithAuth<UsersListParameters>): Promise<UsersListResponse> => {
-      return this.request<UsersListResponse>({
-        path: usersList.path(),
-        method: usersList.method,
-        query: pick(args, usersList.queryParams),
-        body: pick(args, usersList.bodyParams),
-        auth: args?.auth,
-      });
-    },
-  };
+	/**
+	 * Search
+	 */
+	public search(args: WithAuth<SearchParameters>): Promise<SearchResponse> {
+		return this.request<SearchResponse>({
+			path: search.path(),
+			method: search.method,
+			query: pick(args, search.queryParams),
+			body: pick(args, search.bodyParams),
+			auth: args?.auth,
+		})
+	}
 
-  /**
-   * Search
-   */
-  public search(args: WithAuth<SearchParameters>): Promise<SearchResponse> {
-    return this.request<SearchResponse>({
-      path: search.path(),
-      method: search.method,
-      query: pick(args, search.queryParams),
-      body: pick(args, search.bodyParams),
-      auth: args?.auth,
-    });
-  }
+	/**
+	 * Emits a log message to the console.
+	 *
+	 * @param level The level for this message
+	 * @param args Arguments to send to the console
+	 */
+	private log(
+		level: LogLevel,
+		message: string,
+		extraInfo: Record<string, unknown>
+	) {
+		if (logLevelSeverity(level) >= logLevelSeverity(this.#logLevel)) {
+			this.#logger(level, message, extraInfo)
+		}
+	}
 
-  /**
-   * Emits a log message to the console.
-   *
-   * @param level The level for this message
-   * @param args Arguments to send to the console
-   */
-  private log(level: LogLevel, message: string, extraInfo: Record<string, unknown>) {
-    if (logLevelSeverity(level) >= logLevelSeverity(this.#logLevel)) {
-      this.#logger(level, message, extraInfo);
-    }
-  }
-
-  /**
-   * Transforms an API key or access token into a headers object suitable for an HTTP request.
-   *
-   * This method uses the instance's value as the default when the input is undefined. If neither are defined, it returns
-   * an empty object
-   *
-   * @param auth API key or access token
-   * @returns headers key-value object
-   */
-  private authAsHeaders(auth?: string): GotHeaders {
-    const headers: GotHeaders = {};
-    const authHeaderValue = auth ?? this.#auth;
-    if (authHeaderValue !== undefined) {
-      headers['authorization'] = `Bearer ${authHeaderValue}`;
-    }
-    return headers;
-  }
+	/**
+	 * Transforms an API key or access token into a headers object suitable for an HTTP request.
+	 *
+	 * This method uses the instance's value as the default when the input is undefined. If neither are defined, it returns
+	 * an empty object
+	 *
+	 * @param auth API key or access token
+	 * @returns headers key-value object
+	 */
+	private authAsHeaders(auth?: string): GotHeaders {
+		const headers: GotHeaders = {}
+		const authHeaderValue = auth ?? this.#auth
+		if (authHeaderValue !== undefined) {
+			headers["authorization"] = `Bearer ${authHeaderValue}`
+		}
+		return headers
+	}
 }
 
 /*
  * Type aliases to support the generic request interface.
  */
-type Method = 'get' | 'post' | 'patch';
-type QueryParams = GotOptions['searchParams'];
+type Method = "get" | "post" | "patch"
+type QueryParams = GotOptions["searchParams"]
 
-
-type WithAuth<P> = P & { auth?: string };
+type WithAuth<P> = P & { auth?: string }
 
 /*
  * Helper functions
  */
 
-function makeAgentOption(prefixUrl: string, agent: Agent | undefined): GotAgents | undefined {
-  if (agent === undefined) {
-    return undefined;
-  }
-  return {
-    [selectProtocol(prefixUrl)]: agent,
-  };
+function makeAgentOption(
+	prefixUrl: string,
+	agent: Agent | undefined
+): GotAgents | undefined {
+	if (agent === undefined) {
+		return undefined
+	}
+	return {
+		[selectProtocol(prefixUrl)]: agent,
+	}
 }
 
-function selectProtocol(prefixUrl: string): 'http' | 'https' {
-  const url = new URL(prefixUrl);
+function selectProtocol(prefixUrl: string): "http" | "https" {
+	const url = new URL(prefixUrl)
 
-  if (url.protocol === 'https:') {
-    return 'https';
-  } else if (url.protocol === 'http:') {
-    return 'http';
-  }
+	if (url.protocol === "https:") {
+		return "https"
+	} else if (url.protocol === "http:") {
+		return "http"
+	}
 
-  throw new TypeError(`baseUrl option must begin with "https://" or "http://"`);
+	throw new TypeError(`baseUrl option must begin with "https://" or "http://"`)
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -82,7 +82,7 @@ export default class Client {
 		this.#logLevel = options?.logLevel ?? LogLevel.WARN
 		this.#logger = options?.logger ?? makeConsoleLogger(this.constructor.name)
 
-		const prefixUrl = (options?.baseUrl ?? "https://api.notion.com") + "/v1/"
+		const prefixUrl = `${options?.baseUrl ?? "https://api.notion.com"}/v1/`
 		const timeout = options?.timeoutMs ?? 60_000
 		const notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
 

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -7,21 +7,21 @@
  */
 
 import {
-  PaginatedList,
-  PaginationParameters,
-
-  Database,
-  Page,
-  ParentInput,
-  PropertyValue,
-  Block, BlockBase,
-  User, UserBase,
-
-  Filter,
-  Sort,
-  SearchSort,
-  SearchFilter,
-} from './api-types';
+	PaginatedList,
+	PaginationParameters,
+	Database,
+	Page,
+	ParentInput,
+	PropertyValue,
+	Block,
+	BlockBase,
+	User,
+	UserBase,
+	Filter,
+	Sort,
+	SearchSort,
+	SearchFilter,
+} from "./api-types"
 
 // TODO: type assertions to verify that each interface is synchronized to the list of keys in the runtime value below.
 
@@ -33,44 +33,52 @@ import {
  */
 
 interface BlocksChildrenAppendPathParameters {
-  block_id: string;
+	block_id: string
 }
 interface BlocksChildrenAppendQueryParameters {}
 interface BlocksChildrenAppendBodyParameters {
-  children: Block[];
+	children: Block[]
 }
 
-export interface BlocksChildrenAppendParameters extends BlocksChildrenAppendPathParameters, BlocksChildrenAppendQueryParameters, BlocksChildrenAppendBodyParameters {}
+export interface BlocksChildrenAppendParameters
+	extends BlocksChildrenAppendPathParameters,
+		BlocksChildrenAppendQueryParameters,
+		BlocksChildrenAppendBodyParameters {}
 export interface BlocksChildrenAppendResponse extends BlockBase {}
 
 export const blocksChildrenAppend = {
-  method: 'patch',
-  pathParams: ['block_id'],
-  queryParams: [],
-  bodyParams: ['children'],
-  path: (p: BlocksChildrenAppendPathParameters) => `blocks/${p.block_id}/children`,
-} as const;
+	method: "patch",
+	pathParams: ["block_id"],
+	queryParams: [],
+	bodyParams: ["children"],
+	path: (p: BlocksChildrenAppendPathParameters) =>
+		`blocks/${p.block_id}/children`,
+} as const
 
 /*
  * blocks.children.list()
  */
 
 interface BlocksChildrenListPathParameters {
-  block_id: string;
+	block_id: string
 }
 interface BlocksChildrenListQueryParameters extends PaginationParameters {}
 interface BlocksChildrenListBodyParameters {}
 
-export interface BlocksChildrenListParameters extends BlocksChildrenListPathParameters, BlocksChildrenListQueryParameters, BlocksChildrenListBodyParameters {}
+export interface BlocksChildrenListParameters
+	extends BlocksChildrenListPathParameters,
+		BlocksChildrenListQueryParameters,
+		BlocksChildrenListBodyParameters {}
 export interface BlocksChildrenListResponse extends PaginatedList<Block> {}
 
 export const blocksChildrenList = {
-  method: 'get',
-  pathParams: ['block_id'],
-  queryParams: ['start_cursor', 'page_size'],
-  bodyParams: [],
-  path: (p: BlocksChildrenListPathParameters) => `blocks/${p.block_id}/children`,
-} as const;
+	method: "get",
+	pathParams: ["block_id"],
+	queryParams: ["start_cursor", "page_size"],
+	bodyParams: [],
+	path: (p: BlocksChildrenListPathParameters) =>
+		`blocks/${p.block_id}/children`,
+} as const
 
 /*
  * databases.list()
@@ -80,61 +88,70 @@ interface DatabasesListPathParameters {}
 interface DatabasesListQueryParameters extends PaginationParameters {}
 interface DatabasesListBodyParameters {}
 
-export interface DatabasesListParameters extends DatabasesListPathParameters, DatabasesListQueryParameters, DatabasesListBodyParameters {}
+export interface DatabasesListParameters
+	extends DatabasesListPathParameters,
+		DatabasesListQueryParameters,
+		DatabasesListBodyParameters {}
 export interface DatabasesListResponse extends PaginatedList<Database> {}
 
 export const databasesList = {
-  method: 'get',
-  pathParams: [],
-  queryParams: ['start_cursor', 'page_size'],
-  bodyParams: [],
-  path: () => `databases`,
-} as const;
+	method: "get",
+	pathParams: [],
+	queryParams: ["start_cursor", "page_size"],
+	bodyParams: [],
+	path: () => `databases`,
+} as const
 
 /*
  * databases.query()
  */
 
 interface DatabasesQueryPathParameters {
-  database_id: string;
+	database_id: string
 }
 interface DatabasesQueryQueryParameters {}
 interface DatabasesQueryBodyParameters extends PaginationParameters {
-  filter?: Filter;
-  sorts?: Sort[];
+	filter?: Filter
+	sorts?: Sort[]
 }
 
-export interface DatabasesQueryParameters extends DatabasesQueryPathParameters, DatabasesQueryQueryParameters, DatabasesQueryBodyParameters {}
+export interface DatabasesQueryParameters
+	extends DatabasesQueryPathParameters,
+		DatabasesQueryQueryParameters,
+		DatabasesQueryBodyParameters {}
 export interface DatabasesQueryResponse extends PaginatedList<Page> {}
 
 export const databasesQuery = {
-  method: 'post',
-  pathParams: ['database_id'],
-  queryParams: [],
-  bodyParams: ['filter', 'sorts', 'start_cursor', 'page_size'],
-  path: (p: DatabasesQueryPathParameters) => `databases/${p.database_id}/query`,
-} as const;
+	method: "post",
+	pathParams: ["database_id"],
+	queryParams: [],
+	bodyParams: ["filter", "sorts", "start_cursor", "page_size"],
+	path: (p: DatabasesQueryPathParameters) => `databases/${p.database_id}/query`,
+} as const
 
 /*
  * databases.retrieve()
  */
 
 interface DatabasesRetrievePathParameters {
-  database_id: string;
+	database_id: string
 }
 interface DatabasesRetrieveQueryParameters {}
 interface DatabasesRetrieveBodyParameters {}
 
-export interface DatabasesRetrieveParameters extends DatabasesRetrievePathParameters, DatabasesRetrieveQueryParameters, DatabasesRetrieveBodyParameters {}
+export interface DatabasesRetrieveParameters
+	extends DatabasesRetrievePathParameters,
+		DatabasesRetrieveQueryParameters,
+		DatabasesRetrieveBodyParameters {}
 export interface DatabasesRetrieveResponse extends Database {}
 
 export const databasesRetrieve = {
-  method: 'get',
-  pathParams: ['database_id'],
-  queryParams: [],
-  bodyParams: [],
-  path: (p: DatabasesRetrievePathParameters) => `databases/${p.database_id}`,
-} as const;
+	method: "get",
+	pathParams: ["database_id"],
+	queryParams: [],
+	bodyParams: [],
+	path: (p: DatabasesRetrievePathParameters) => `databases/${p.database_id}`,
+} as const
 
 /*
  * pages.create()
@@ -143,20 +160,23 @@ export const databasesRetrieve = {
 interface PagesCreatePathParameters {}
 interface PagesCreateQueryParameters {}
 interface PagesCreateBodyParameters {
-  parent: ParentInput;
-  properties: { [propertyName: string]: PropertyValue; };
-  children?: Block[];
+	parent: ParentInput
+	properties: { [propertyName: string]: PropertyValue }
+	children?: Block[]
 }
 
-export interface PagesCreateParameters extends PagesCreatePathParameters, PagesCreateQueryParameters, PagesCreateBodyParameters {}
+export interface PagesCreateParameters
+	extends PagesCreatePathParameters,
+		PagesCreateQueryParameters,
+		PagesCreateBodyParameters {}
 export interface PagesCreateResponse extends BlockBase {}
 
 export const pagesCreate = {
-  method: 'post',
-  pathParams: [],
-  queryParams: [],
-  bodyParams: ['parent', 'properties', 'children'],
-  path: () => `pages`,
+	method: "post",
+	pathParams: [],
+	queryParams: [],
+	bodyParams: ["parent", "properties", "children"],
+	path: () => `pages`,
 } as const
 
 /*
@@ -164,65 +184,74 @@ export const pagesCreate = {
  */
 
 interface PagesRetrievePathParameters {
-  page_id: string;
+	page_id: string
 }
 interface PagesRetrieveQueryParameters {}
 interface PagesRetrieveBodyParameters {}
 
-export interface PagesRetrieveParameters extends PagesRetrievePathParameters, PagesRetrieveQueryParameters, PagesRetrieveBodyParameters {}
+export interface PagesRetrieveParameters
+	extends PagesRetrievePathParameters,
+		PagesRetrieveQueryParameters,
+		PagesRetrieveBodyParameters {}
 export interface PagesRetrieveResponse extends Page {}
 
 export const pagesRetrieve = {
-  method: 'get',
-  pathParams: ['page_id'],
-  queryParams: [],
-  bodyParams: [],
-  path: (p: PagesRetrievePathParameters) => `pages/${p.page_id}`,
-} as const;
+	method: "get",
+	pathParams: ["page_id"],
+	queryParams: [],
+	bodyParams: [],
+	path: (p: PagesRetrievePathParameters) => `pages/${p.page_id}`,
+} as const
 
 /*
  * pages.update()
  */
 
 interface PagesUpdatePathParameters {
-  page_id: string;
+	page_id: string
 }
 interface PagesUpdateQueryParameters {}
 interface PagesUpdateBodyParameters {
-  properties: { [propertyNameOrId: string]: PropertyValue; };
+	properties: { [propertyNameOrId: string]: PropertyValue }
 }
 
-export interface PagesUpdateParameters extends PagesUpdatePathParameters, PagesUpdateQueryParameters, PagesUpdateBodyParameters {}
+export interface PagesUpdateParameters
+	extends PagesUpdatePathParameters,
+		PagesUpdateQueryParameters,
+		PagesUpdateBodyParameters {}
 export interface PagesUpdateResponse extends Page {}
 
 export const pagesUpdate = {
-  method: 'patch',
-  pathParams: ['page_id'],
-  queryParams: [],
-  bodyParams: ['properties'],
-  path: (p: PagesUpdatePathParameters) => `pages/${p.page_id}`,
-} as const;
+	method: "patch",
+	pathParams: ["page_id"],
+	queryParams: [],
+	bodyParams: ["properties"],
+	path: (p: PagesUpdatePathParameters) => `pages/${p.page_id}`,
+} as const
 
 /*
  * users.retrieve()
  */
 
 interface UsersRetrievePathParameters {
-  user_id: string;
+	user_id: string
 }
 interface UsersRetrieveQueryParameters {}
 interface UsersRetrieveBodyParameters {}
 
-export interface UsersRetrieveParameters extends UsersRetrievePathParameters, UsersRetrieveQueryParameters, UsersRetrieveBodyParameters {}
+export interface UsersRetrieveParameters
+	extends UsersRetrievePathParameters,
+		UsersRetrieveQueryParameters,
+		UsersRetrieveBodyParameters {}
 export interface UsersRetrieveResponse extends UserBase {}
 
 export const usersRetrieve = {
-  method: 'get',
-  pathParams: ['user_id'],
-  queryParams: [],
-  bodyParams: [],
-  path: (p: UsersRetrievePathParameters) => `users/${p.user_id}`,
-} as const;
+	method: "get",
+	pathParams: ["user_id"],
+	queryParams: [],
+	bodyParams: [],
+	path: (p: UsersRetrievePathParameters) => `users/${p.user_id}`,
+} as const
 
 /*
  * users.list()
@@ -232,16 +261,19 @@ interface UsersListPathParameters {}
 interface UsersListQueryParameters extends PaginationParameters {}
 interface UsersListBodyParameters {}
 
-export interface UsersListParameters extends UsersListPathParameters, UsersListQueryParameters, UsersListBodyParameters {}
+export interface UsersListParameters
+	extends UsersListPathParameters,
+		UsersListQueryParameters,
+		UsersListBodyParameters {}
 export interface UsersListResponse extends PaginatedList<User> {}
 
 export const usersList = {
-  method: 'get',
-  pathParams: [],
-  queryParams: ['start_cursor', 'page_size'],
-  bodyParams: [],
-  path: () => `users`,
-} as const;
+	method: "get",
+	pathParams: [],
+	queryParams: ["start_cursor", "page_size"],
+	bodyParams: [],
+	path: () => `users`,
+} as const
 
 /*
  * search()
@@ -250,18 +282,21 @@ export const usersList = {
 interface SearchPathParameters {}
 interface SearchQueryParameters {}
 interface SearchBodyParameters extends PaginationParameters {
-  query?: string;
-  sort?: SearchSort;
-  filter?: SearchFilter;
+	query?: string
+	sort?: SearchSort
+	filter?: SearchFilter
 }
 
-export interface SearchParameters extends SearchPathParameters, SearchQueryParameters, SearchBodyParameters {}
+export interface SearchParameters
+	extends SearchPathParameters,
+		SearchQueryParameters,
+		SearchBodyParameters {}
 export interface SearchResponse extends PaginatedList<Page | Database> {}
 
 export const search = {
-  method: 'post',
-  pathParams: [],
-  queryParams: [],
-  bodyParams: ['query', 'sort', 'filter', 'start_cursor', 'page_size'],
-  path: () => `search`,
-} as const;
+	method: "post",
+	pathParams: [],
+	queryParams: [],
+	bodyParams: ["query", "sort", "filter", "start_cursor", "page_size"],
+	path: () => `search`,
+} as const

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -5,29 +5,30 @@
  * In the future, the contents of this file will be generated from an API definition.
  */
 
-
 /*
  * Pagination
  */
 
 export interface PaginationParameters {
-  start_cursor?: string;
-  page_size?: number;
+	start_cursor?: string
+	page_size?: number
 }
 
-export interface PaginatedList<O extends APISingularObject = APISingularObject> {
-  object: 'list',
-  results: O[],
-  has_more: boolean;
-  next_cursor: string | null;
+export interface PaginatedList<
+	O extends APISingularObject = APISingularObject
+> {
+	object: "list"
+	results: O[]
+	has_more: boolean
+	next_cursor: string | null
 }
 
 /*
  * API Objects
  */
 
-export type APIObject = APISingularObject | PaginatedList;
-export type APISingularObject = Database | Page | User | Block;
+export type APIObject = APISingularObject | PaginatedList
+export type APISingularObject = Database | Page | User | Block
 
 /*
  * Block (outputs)
@@ -36,83 +37,82 @@ export type APISingularObject = Database | Page | User | Block;
 // TODO: need an input version of this type. maybe reuse distributiveomit. but what about richtext id's?
 
 export type Block =
-  | ParagraphBlock
-  | HeadingOneBlock
-  | HeadingTwoBlock
-  | HeadingThreeBlock
-  | BulletedListItemBlock
-  | NumberedListItemBlock
-  | ToDoBlock
-  | ToggleBlock
-  | ChildPageBlock
-  | UnsupportedBlock;
-
+	| ParagraphBlock
+	| HeadingOneBlock
+	| HeadingTwoBlock
+	| HeadingThreeBlock
+	| BulletedListItemBlock
+	| NumberedListItemBlock
+	| ToDoBlock
+	| ToggleBlock
+	| ChildPageBlock
+	| UnsupportedBlock
 
 export interface BlockBase {
-  object: 'block';
-  id: string;
-  type: string;
-  created_time: string;
-  last_edited_time: string;
-  has_children: boolean;
+	object: "block"
+	id: string
+	type: string
+	created_time: string
+	last_edited_time: string
+	has_children: boolean
 }
 
 export interface ParagraphBlock extends BlockBase {
-  type: 'paragraph';
-  text: RichText[];
-  children?: BlockBase[];
+	type: "paragraph"
+	text: RichText[]
+	children?: BlockBase[]
 }
 
 export interface HeadingOneBlock extends BlockBase {
-  type: 'heading_1';
-  text: RichText[];
-  has_children: false;
+	type: "heading_1"
+	text: RichText[]
+	has_children: false
 }
 
 export interface HeadingTwoBlock extends BlockBase {
-  type: 'heading_2';
-  text: RichText[];
-  has_children: false;
+	type: "heading_2"
+	text: RichText[]
+	has_children: false
 }
 
 export interface HeadingThreeBlock extends BlockBase {
-  type: 'heading_3';
-  text: RichText[];
-  has_children: false;
+	type: "heading_3"
+	text: RichText[]
+	has_children: false
 }
 
 export interface BulletedListItemBlock extends BlockBase {
-  type: 'bulleted_list_item';
-  text: RichText[];
-  children?: BlockBase[];
+	type: "bulleted_list_item"
+	text: RichText[]
+	children?: BlockBase[]
 }
 
 export interface NumberedListItemBlock extends BlockBase {
-  type: 'numbered_list_item';
-  text: RichText[];
-  children?: BlockBase[];
+	type: "numbered_list_item"
+	text: RichText[]
+	children?: BlockBase[]
 }
 
 export interface ToDoBlock extends BlockBase {
-  type: 'to_do';
-  text: RichText[];
-  checked: boolean;
-  children?: BlockBase[];
+	type: "to_do"
+	text: RichText[]
+	checked: boolean
+	children?: BlockBase[]
 }
 
 export interface ToggleBlock extends BlockBase {
-  type: 'toggle';
-  text: RichText[];
-  children?: BlockBase[];
+	type: "toggle"
+	text: RichText[]
+	children?: BlockBase[]
 }
 
 export interface ChildPageBlock extends BlockBase {
-  type: 'child_page';
-  title: string;
+	type: "child_page"
+	title: string
 }
 
 export interface UnsupportedBlock extends BlockBase {
-  type: 'unsupported';
+	type: "unsupported"
 }
 
 /*
@@ -120,12 +120,12 @@ export interface UnsupportedBlock extends BlockBase {
  */
 
 export interface Database {
-  object: 'database';
-  id: string;
-  created_time: string;
-  last_edited_time: string;
-  title: RichText[];
-  properties: { [propertyName: string] : Property };
+	object: "database"
+	id: string
+	created_time: string
+	last_edited_time: string
+	title: RichText[]
+	properties: { [propertyName: string]: Property }
 }
 
 /*
@@ -133,304 +133,345 @@ export interface Database {
  */
 
 export type Property =
-  | TitleProperty
-  | RichTextProperty
-  | NumberProperty
-  | SelectProperty
-  | MultiSelectProperty
-  | DateProperty
-  | PeopleProperty
-  | FileProperty
-  | CheckboxProperty
-  | URLProperty
-  | EmailProperty
-  | PhoneNumberProperty
-  | FormulaProperty
-  | RelationProperty
-  | RollupProperty
-  | CreatedTimeProperty
-  | CreatedByProperty
-  | LastEditedTimeProperty
-  | LastEditedByProperty;
+	| TitleProperty
+	| RichTextProperty
+	| NumberProperty
+	| SelectProperty
+	| MultiSelectProperty
+	| DateProperty
+	| PeopleProperty
+	| FileProperty
+	| CheckboxProperty
+	| URLProperty
+	| EmailProperty
+	| PhoneNumberProperty
+	| FormulaProperty
+	| RelationProperty
+	| RollupProperty
+	| CreatedTimeProperty
+	| CreatedByProperty
+	| LastEditedTimeProperty
+	| LastEditedByProperty
 
 export interface PropertyBase {
-  id: string;
-  type: string;
+	id: string
+	type: string
 }
 
 export interface TitleProperty extends PropertyBase {
-  type: 'title';
-  title: Record<string, never>;
+	type: "title"
+	title: Record<string, never>
 }
 
 export interface RichTextProperty extends PropertyBase {
-  type: 'rich_text';
-  rich_text: Record<string, never>;
+	type: "rich_text"
+	rich_text: Record<string, never>
 }
 
 export interface NumberProperty extends PropertyBase {
-  type: 'number';
-  number: {
-    format: 'number' | 'number_with_commas' | 'percent' | 'dollar' | 'euro' | 'pound' | 'yen' | 'ruble' | 'rupee' | 'won' | 'yuan';
-  }
+	type: "number"
+	number: {
+		format:
+			| "number"
+			| "number_with_commas"
+			| "percent"
+			| "dollar"
+			| "euro"
+			| "pound"
+			| "yen"
+			| "ruble"
+			| "rupee"
+			| "won"
+			| "yuan"
+	}
 }
 
 export interface SelectProperty extends PropertyBase {
-  type: 'select';
-  select: SelectOption[];
+	type: "select"
+	select: SelectOption[]
 }
 
 export interface MultiSelectProperty extends PropertyBase {
-  type: 'multi_select';
-  multi_select: MultiSelectOption[];
+	type: "multi_select"
+	multi_select: MultiSelectOption[]
 }
 
 export interface DateProperty extends PropertyBase {
-  type: 'date';
-  date: Record<string, never>;
+	type: "date"
+	date: Record<string, never>
 }
 
 export interface PeopleProperty extends PropertyBase {
-  type: 'people';
-  people: Record<string, never>;
+	type: "people"
+	people: Record<string, never>
 }
 
 export interface FileProperty extends PropertyBase {
-  type: 'file';
-  file: Record<string, never>;
+	type: "file"
+	file: Record<string, never>
 }
 
 export interface CheckboxProperty extends PropertyBase {
-  type: 'checkbox';
-  checkbox: Record<string, never>;
+	type: "checkbox"
+	checkbox: Record<string, never>
 }
 
 export interface URLProperty extends PropertyBase {
-  type: 'url';
-  url: Record<string, never>;
+	type: "url"
+	url: Record<string, never>
 }
 
 export interface EmailProperty extends PropertyBase {
-  type: 'email';
-  email: Record<string, never>;
+	type: "email"
+	email: Record<string, never>
 }
 
 export interface PhoneNumberProperty extends PropertyBase {
-  type: 'phone_number';
-  phone_number: Record<string, never>;
+	type: "phone_number"
+	phone_number: Record<string, never>
 }
 
 export interface FormulaProperty extends PropertyBase {
-  type: 'formula';
-  formula: {
-    expression: string;
-  };
+	type: "formula"
+	formula: {
+		expression: string
+	}
 }
 
 export interface RelationProperty extends PropertyBase {
-  type: 'relation';
-  relation: {
-    database_id: string;
-    synced_property_name?: string;
-    synced_property_id?: string;
-  }
+	type: "relation"
+	relation: {
+		database_id: string
+		synced_property_name?: string
+		synced_property_id?: string
+	}
 }
 
 export interface RollupProperty extends PropertyBase {
-  type: 'rollup';
-  rollup: {
-    relation_property_name: string;
-    relation_property_id: string;
-    rollup_property_name: string;
-    rollup_property_id: string;
-    function: 'count_all' | 'count_values' | 'count_unique_values' | 'count_empty' | 'count_not_empty' | 'percent_empty' | 'percent_not_empty' | 'sum' | 'average' | 'median' | 'min' | 'max' | 'range';
-  }
+	type: "rollup"
+	rollup: {
+		relation_property_name: string
+		relation_property_id: string
+		rollup_property_name: string
+		rollup_property_id: string
+		function:
+			| "count_all"
+			| "count_values"
+			| "count_unique_values"
+			| "count_empty"
+			| "count_not_empty"
+			| "percent_empty"
+			| "percent_not_empty"
+			| "sum"
+			| "average"
+			| "median"
+			| "min"
+			| "max"
+			| "range"
+	}
 }
 
 export interface CreatedTimeProperty extends PropertyBase {
-  type: 'created_time';
-  created_time: Record<string, never>;
+	type: "created_time"
+	created_time: Record<string, never>
 }
 
 export interface CreatedByProperty extends PropertyBase {
-  type: 'created_by';
-  created_by: Record<string, never>;
+	type: "created_by"
+	created_by: Record<string, never>
 }
 
 export interface LastEditedTimeProperty extends PropertyBase {
-  type: 'last_edited_time';
-  last_edited_time: Record<string, never>;
+	type: "last_edited_time"
+	last_edited_time: Record<string, never>
 }
 
 export interface LastEditedByProperty extends PropertyBase {
-  type: 'last_edited_by';
-  last_edited_by: Record<string, never>;
+	type: "last_edited_by"
+	last_edited_by: Record<string, never>
 }
 
 /*
  * User (output)
  */
 
-export type User = PersonUser | BotUser;
+export type User = PersonUser | BotUser
 
 export interface UserBase {
-  object: 'user';
-  id: string;
-  type?: string;
-  name?: string;
-  avatar_url?: string;
+	object: "user"
+	id: string
+	type?: string
+	name?: string
+	avatar_url?: string
 }
 
 export interface PersonUser extends UserBase {
-  type?: 'person';
-  person?: {
-    email: string;
-  };
+	type?: "person"
+	person?: {
+		email: string
+	}
 }
 
 export interface BotUser extends UserBase {
-  type?: 'bot';
+	type?: "bot"
 }
-
 
 /*
  * Misc (output)
  */
 
 export interface SelectOption {
-  name: string;
-  id: string;
-  color: Color;
+	name: string
+	id: string
+	color: Color
 }
 
 export interface MultiSelectOption {
-  name: string;
-  id: string;
-  color: Color;
+	name: string
+	id: string
+	color: Color
 }
 
-
 export interface SearchSort {
-  direction: 'ascending' | 'descending';
-  timestamp: 'last_edited_time';
+	direction: "ascending" | "descending"
+	timestamp: "last_edited_time"
 }
 
 export interface SearchFilter {
-  value: 'object',
-  property: 'object';
+	value: "object"
+	property: "object"
 }
 
-export type Color = 'default' | 'gray' | 'brown' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'red';
-export type BackgroundColor = 'gray_background' | 'brown_background' | 'orange_background' | 'yellow_background' | 'green_background' | 'blue_background' | 'purple_background' | 'pink_background' | 'red_background';
+export type Color =
+	| "default"
+	| "gray"
+	| "brown"
+	| "orange"
+	| "yellow"
+	| "green"
+	| "blue"
+	| "purple"
+	| "pink"
+	| "red"
+export type BackgroundColor =
+	| "gray_background"
+	| "brown_background"
+	| "orange_background"
+	| "yellow_background"
+	| "green_background"
+	| "blue_background"
+	| "purple_background"
+	| "pink_background"
+	| "red_background"
 
 /*
  * Filter (input)
  */
 
-export type Filter = SinglePropertyFilter | CompoundFilter;
+export type Filter = SinglePropertyFilter | CompoundFilter
 
 export type SinglePropertyFilter =
-  | TextFilter
-  | NumberFilter
-  | CheckboxFilter
-  | SelectFilter
-  | MultiSelectFilter
-  | DateFilter
-  | PeopleFilter
-  | FilesFilter
-  | RelationFilter
-  | FormulaFilter
+	| TextFilter
+	| NumberFilter
+	| CheckboxFilter
+	| SelectFilter
+	| MultiSelectFilter
+	| DateFilter
+	| PeopleFilter
+	| FilesFilter
+	| RelationFilter
+	| FormulaFilter
 
 export interface CompoundFilter {
-  or?: Filter[];
-  and?: Filter[];
+	or?: Filter[]
+	and?: Filter[]
 }
 
 export interface SinglePropertyFilterBase {
-  property: string;
+	property: string
 }
 
 export interface TextFilter extends SinglePropertyFilterBase {
-  equals?: string;
-  does_not_equal?: string;
-  contains?: string;
-  does_not_contain?: string;
-  starts_with?: string;
-  ends_with?: string;
-  is_empty?: true;
-  is_not_empty?: true;
+	equals?: string
+	does_not_equal?: string
+	contains?: string
+	does_not_contain?: string
+	starts_with?: string
+	ends_with?: string
+	is_empty?: true
+	is_not_empty?: true
 }
 
 export interface NumberFilter extends SinglePropertyFilterBase {
-  equals?: number;
-  does_not_equal?: number;
-  greater_than?: number;
-  less_than?: number;
-  greater_than_or_equal_to?: number;
-  less_than_or_equal_to?: number;
-  is_empty?: true;
-  is_not_empty?: true;
+	equals?: number
+	does_not_equal?: number
+	greater_than?: number
+	less_than?: number
+	greater_than_or_equal_to?: number
+	less_than_or_equal_to?: number
+	is_empty?: true
+	is_not_empty?: true
 }
 
 export interface CheckboxFilter extends SinglePropertyFilterBase {
-  equals?: boolean;
-  does_not_equal?: boolean;
+	equals?: boolean
+	does_not_equal?: boolean
 }
 
 export interface SelectFilter extends SinglePropertyFilterBase {
-  equals?: string;
-  does_not_equal?: string;
-  is_empty?: true;
-  is_not_empty?: true;
+	equals?: string
+	does_not_equal?: string
+	is_empty?: true
+	is_not_empty?: true
 }
 
 export interface MultiSelectFilter extends SinglePropertyFilterBase {
-  contains?: string;
-  does_not_contain?: string;
-  is_empty?: true;
-  is_not_empty?: true;
+	contains?: string
+	does_not_contain?: string
+	is_empty?: true
+	is_not_empty?: true
 }
 
 export interface DateFilter extends SinglePropertyFilterBase {
-  equals?: string;
-  before?: string;
-  after?: string;
-  on_or_before?: string;
-  is_empty?: true;
-  is_not_empty?: true;
-  on_or_after?: string;
-  past_week: Record<string, never>;
-  past_month: Record<string, never>;
-  past_year: Record<string, never>;
-  next_week: Record<string, never>;
-  next_month: Record<string, never>;
-  next_year: Record<string, never>;
+	equals?: string
+	before?: string
+	after?: string
+	on_or_before?: string
+	is_empty?: true
+	is_not_empty?: true
+	on_or_after?: string
+	past_week: Record<string, never>
+	past_month: Record<string, never>
+	past_year: Record<string, never>
+	next_week: Record<string, never>
+	next_month: Record<string, never>
+	next_year: Record<string, never>
 }
 
 export interface PeopleFilter extends SinglePropertyFilterBase {
-  contains?: string;
-  does_not_contain?: string;
-  is_empty?: true;
-  is_not_empty?: true;
+	contains?: string
+	does_not_contain?: string
+	is_empty?: true
+	is_not_empty?: true
 }
 
 export interface FilesFilter extends SinglePropertyFilterBase {
-  is_empty?: true;
-  is_not_empty?: true;
+	is_empty?: true
+	is_not_empty?: true
 }
 
 export interface RelationFilter extends SinglePropertyFilterBase {
-  contains?: string;
-  does_not_contain?: string;
-  is_empty?: true;
-  is_not_empty?: true;
+	contains?: string
+	does_not_contain?: string
+	is_empty?: true
+	is_not_empty?: true
 }
 
 export interface FormulaFilter extends SinglePropertyFilterBase {
-  text?: Omit<TextFilter, 'property'>;
-  checkbox?: Omit<CheckboxFilter, 'property'>;
-  number?: Omit<NumberFilter, 'property'>;
-  date?: Omit<DateFilter, 'property'>;
+	text?: Omit<TextFilter, "property">
+	checkbox?: Omit<CheckboxFilter, "property">
+	number?: Omit<NumberFilter, "property">
+	date?: Omit<DateFilter, "property">
 }
 
 /*
@@ -438,9 +479,9 @@ export interface FormulaFilter extends SinglePropertyFilterBase {
  */
 
 export interface Sort {
-  property?: string;
-  timestamp?: 'created_time' | 'last_edited_time';
-  direction: 'ascending' | 'descending';
+	property?: string
+	timestamp?: "created_time" | "last_edited_time"
+	direction: "ascending" | "descending"
 }
 
 /*
@@ -448,34 +489,35 @@ export interface Sort {
  */
 
 export interface Page {
-  object: 'page',
-  id: string;
-  parent: Parent;
-  properties: { [propertyName: string]: PropertyValue };
+	object: "page"
+	id: string
+	parent: Parent
+	properties: { [propertyName: string]: PropertyValue }
 }
 
 /*
  * Parent
  */
 
-export type Parent = DatabaseParent | PageParent | WorkspaceParent;
-export type ParentInput = Omit<DatabaseParent, 'type'> |  Omit<PageParent, 'type'>;
+export type Parent = DatabaseParent | PageParent | WorkspaceParent
+export type ParentInput =
+	| Omit<DatabaseParent, "type">
+	| Omit<PageParent, "type">
 // TODO: use distributiveomit?
 
 export interface DatabaseParent {
-  type: 'database_id';
-  database_id: string;
+	type: "database_id"
+	database_id: string
 }
 
 export interface PageParent {
-  type: 'page_id';
-  page_id: string;
+	type: "page_id"
+	page_id: string
 }
 
 export interface WorkspaceParent {
-  type: 'workspace';
+	type: "workspace"
 }
-
 
 /*
  * PropertyValue
@@ -487,218 +529,222 @@ export interface WorkspaceParent {
 //     : never;
 
 export type PropertyValue =
- | TitlePropertyValue
- | RichTextPropertyValue
- | NumberPropertyValue
- | SelectPropertyValue
- | MultiSelectPropertyValue
- | DatePropertyValue
- | FormulaPropertyValue
- | RollupPropertyValue
- | PeoplePropertyValue
- | FilesPropertyValue
- | CheckboxPropertyValue
- | URLPropertyValue
- | EmailPropertyValue
- | PhoneNumberPropertyValue
- | CreatedTimePropertyValue
- | CreatedByPropertyValue
- | LastEditedTimePropertyValue
- | LastEditedByPropertyValue;
+	| TitlePropertyValue
+	| RichTextPropertyValue
+	| NumberPropertyValue
+	| SelectPropertyValue
+	| MultiSelectPropertyValue
+	| DatePropertyValue
+	| FormulaPropertyValue
+	| RollupPropertyValue
+	| PeoplePropertyValue
+	| FilesPropertyValue
+	| CheckboxPropertyValue
+	| URLPropertyValue
+	| EmailPropertyValue
+	| PhoneNumberPropertyValue
+	| CreatedTimePropertyValue
+	| CreatedByPropertyValue
+	| LastEditedTimePropertyValue
+	| LastEditedByPropertyValue
 
 export interface PropertyValueBase {
-  id: string;
-  type: string;
+	id: string
+	type: string
 }
 
 export interface TitlePropertyValue extends PropertyValueBase {
-  type: 'title';
-  title: RichText[];
+	type: "title"
+	title: RichText[]
 }
 
 export interface RichTextPropertyValue extends PropertyValueBase {
-  type: 'rich_text';
-  rich_text: RichText[];
+	type: "rich_text"
+	rich_text: RichText[]
 }
 
 export interface NumberPropertyValue extends PropertyValueBase {
-  type: 'number';
-  number: number;
+	type: "number"
+	number: number
 }
 
 export interface SelectPropertyValue extends PropertyValueBase {
-  type: 'select';
-  select: {
-    id: string;
-    name: string;
-    color: Color;
-  };
+	type: "select"
+	select: {
+		id: string
+		name: string
+		color: Color
+	}
 }
 
 export interface MultiSelectPropertyValue extends PropertyValueBase {
-  type: 'multi_select';
-  multi_select: {
-    id: string;
-    name: string;
-    color: Color;
-  };
+	type: "multi_select"
+	multi_select: {
+		id: string
+		name: string
+		color: Color
+	}
 }
 
 export interface DatePropertyValue extends PropertyValueBase {
-  type: 'date';
-  date: {
-    start: string;
-    end?: string;
-  };
+	type: "date"
+	date: {
+		start: string
+		end?: string
+	}
 }
 
 export interface FormulaPropertyValue extends PropertyValueBase {
-  type: 'formula';
-  formula: StringFormulaValue | NumberFormulaValue | BooleanFormulaValue | DateFormulaValue;
+	type: "formula"
+	formula:
+		| StringFormulaValue
+		| NumberFormulaValue
+		| BooleanFormulaValue
+		| DateFormulaValue
 }
 
 export interface StringFormulaValue {
-  type: 'string';
-  string?: string;
+	type: "string"
+	string?: string
 }
 export interface NumberFormulaValue {
-  type: 'number';
-  number?: number;
+	type: "number"
+	number?: number
 }
 export interface BooleanFormulaValue {
-  type: 'boolean';
-  boolean: boolean;
+	type: "boolean"
+	boolean: boolean
 }
 export interface DateFormulaValue {
-  type: 'date';
-  date: DatePropertyValue;
+	type: "date"
+	date: DatePropertyValue
 }
 
 export interface RollupPropertyValue extends PropertyValueBase {
-  type: 'rollup';
-  rollup: NumberRollupValue | DateRollupValue | ArrayRollupValue;
+	type: "rollup"
+	rollup: NumberRollupValue | DateRollupValue | ArrayRollupValue
 }
 
 export interface NumberRollupValue {
-  type: 'number';
-  number: number;
+	type: "number"
+	number: number
 }
 export interface DateRollupValue {
-  type: 'date';
-  date: DatePropertyValue;
+	type: "date"
+	date: DatePropertyValue
 }
 export interface ArrayRollupValue {
-  type: 'array';
-  array: unknown[]; // TODO: this is exactly like PropertyValue but without the `id`
+	type: "array"
+	array: unknown[] // TODO: this is exactly like PropertyValue but without the `id`
 }
 
 export interface PeoplePropertyValue extends PropertyValueBase {
-  type: 'people';
-  people: User[];
+	type: "people"
+	people: User[]
 }
 
 export interface FilesPropertyValue extends PropertyValueBase {
-  type: 'files';
-  files: { name: string; }[];
+	type: "files"
+	files: { name: string }[]
 }
 
 export interface CheckboxPropertyValue extends PropertyValueBase {
-  type: 'checkbox';
-  checkbox: boolean;
+	type: "checkbox"
+	checkbox: boolean
 }
 
 export interface URLPropertyValue extends PropertyValueBase {
-  type: 'url';
-  url: string;
+	type: "url"
+	url: string
 }
 
 export interface EmailPropertyValue extends PropertyValueBase {
-  type: 'email';
-  email: string;
+	type: "email"
+	email: string
 }
 
 export interface PhoneNumberPropertyValue extends PropertyValueBase {
-  type: 'phone_number';
-  phone_number: string;
+	type: "phone_number"
+	phone_number: string
 }
 
 export interface CreatedTimePropertyValue extends PropertyValueBase {
-  type: 'created_time';
-  created_time: string;
+	type: "created_time"
+	created_time: string
 }
 
 export interface CreatedByPropertyValue extends PropertyValueBase {
-  type: 'created_by';
-  created_by: User;
+	type: "created_by"
+	created_by: User
 }
 
 export interface LastEditedTimePropertyValue extends PropertyValueBase {
-  type: 'last_edited_time';
-  last_edited_time: string;
+	type: "last_edited_time"
+	last_edited_time: string
 }
 
 export interface LastEditedByPropertyValue extends PropertyValueBase {
-  type: 'last_edited_by';
-  last_edited_by: User;
+	type: "last_edited_by"
+	last_edited_by: User
 }
 
 /*
  * Rich text object (output)
  */
-export type RichText = RichTextText | RichTextMention | RichTextEquation;
+export type RichText = RichTextText | RichTextMention | RichTextEquation
 
 export interface RichTextBase {
-  plain_text: string;
-  href?: string;
-  annotations: Annotations;
-  type: string;
+	plain_text: string
+	href?: string
+	annotations: Annotations
+	type: string
 }
 
 export interface RichTextText extends RichTextBase {
-  type: 'text';
-  text: {
-    content: string;
-    link?: { type: 'url'; url: string; };
-  };
+	type: "text"
+	text: {
+		content: string
+		link?: { type: "url"; url: string }
+	}
 }
 
 export interface RichTextMention extends RichTextBase {
-  type: 'mention';
-  mention: UserMention | PageMention | DatabaseMention | DateMention;
+	type: "mention"
+	mention: UserMention | PageMention | DatabaseMention | DateMention
 }
 
 export interface UserMention {
-  type: 'user';
-  user: User;
+	type: "user"
+	user: User
 }
 
 export interface PageMention {
-  type: 'page';
-  page: { id: string; };
+	type: "page"
+	page: { id: string }
 }
 
 export interface DatabaseMention {
-  type: 'database';
-  database: { id: string };
+	type: "database"
+	database: { id: string }
 }
 
 export interface DateMention {
-  type: 'date';
-  date: DatePropertyValue;
+	type: "date"
+	date: DatePropertyValue
 }
 
 export interface RichTextEquation extends RichTextBase {
-  type: 'equation';
-  equation: {
-    expression: string;
-  };
+	type: "equation"
+	equation: {
+		expression: string
+	}
 }
 
 export interface Annotations {
-  bold: boolean;
-  italic: boolean;
-  strikethrough: boolean;
-  underline: boolean;
-  code: boolean;
-  color: Color | BackgroundColor;
+	bold: boolean
+	italic: boolean
+	strikethrough: boolean
+	underline: boolean
+	code: boolean
+	color: Color | BackgroundColor
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -88,7 +88,6 @@ export class APIResponseError
 	readonly code: APIErrorCode
 
 	constructor(response: GotResponse, body: APIErrorResponseBody) {
-		console.log("building the error")
 		super(response, body.message)
 		this.name = "APIResponseError"
 		this.code = body.code

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,75 +1,79 @@
-import type { IncomingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders } from "http"
 import type {
-  HTTPError as GotHTTPError,
-  TimeoutError as GotTimeoutError,
-  Response as GotResponse,
-} from 'got';
-import { isObject } from './helpers';
+	HTTPError as GotHTTPError,
+	TimeoutError as GotTimeoutError,
+	Response as GotResponse,
+} from "got"
+import { isObject } from "./helpers"
 
 export class RequestTimeoutError extends Error {
-  readonly code = 'notionhq_client_request_timeout';
+	readonly code = "notionhq_client_request_timeout"
 
-  constructor(message = 'Request to Notion API has timed out') {
-    super(message);
-    this.name = 'RequestTimeoutError';
-  }
+	constructor(message = "Request to Notion API has timed out") {
+		super(message)
+		this.name = "RequestTimeoutError"
+	}
 
-  static isRequestTimeoutError(error: unknown): error is RequestTimeoutError {
-    return (
-      error instanceof Error &&
-      error.name === 'RequestTimeoutError' &&
-      'code' in error && error['code'] === RequestTimeoutError.prototype.code
-    );
-  }
+	static isRequestTimeoutError(error: unknown): error is RequestTimeoutError {
+		return (
+			error instanceof Error &&
+			error.name === "RequestTimeoutError" &&
+			"code" in error &&
+			error["code"] === RequestTimeoutError.prototype.code
+		)
+	}
 }
 
 export class HTTPResponseError extends Error {
-  readonly code: string = 'notionhq_client_response_error';
-  readonly status: number;
-  readonly headers: IncomingHttpHeaders;
-  readonly body: string;
+	readonly code: string = "notionhq_client_response_error"
+	readonly status: number
+	readonly headers: IncomingHttpHeaders
+	readonly body: string
 
-  constructor(response: GotResponse, message?: string) {
-    super(message ?? `Request to Notion API failed with status: ${response.statusCode}`);
-    this.name = 'HTTPResponseError';
-    this.status = response.statusCode;
-    this.headers = response.headers;
-    this.body = response.rawBody.toString();
-  }
+	constructor(response: GotResponse, message?: string) {
+		super(
+			message ??
+				`Request to Notion API failed with status: ${response.statusCode}`
+		)
+		this.name = "HTTPResponseError"
+		this.status = response.statusCode
+		this.headers = response.headers
+		this.body = response.rawBody.toString()
+	}
 
-  static isHTTPResponseError(error: unknown): error is HTTPResponseError {
-    return (
-      error instanceof Error &&
-      error.name === 'HTTPResponseError' &&
-      'code' in error && error['code'] === HTTPResponseError.prototype.code
-    );
-  }
+	static isHTTPResponseError(error: unknown): error is HTTPResponseError {
+		return (
+			error instanceof Error &&
+			error.name === "HTTPResponseError" &&
+			"code" in error &&
+			error["code"] === HTTPResponseError.prototype.code
+		)
+	}
 }
-
 
 /**
  * Error codes for responses from the API.
  */
 export enum APIErrorCode {
-  Unauthorized = 'unauthorized',
-  RestrictedResource = 'restricted_resource',
-  ObjectNotFound = 'object_not_found',
-  RateLimited = 'rate_limited',
-  InvalidJSON = 'invalid_json',
-  InvalidRequestURL = 'invalid_request_url',
-  InvalidRequest = 'invalid_request',
-  ValidationError = 'validation_error',
-  ConflictError = 'conflict_error',
-  InternalServerError = 'internal_server_error',
-  ServiceUnavailable = 'service_unavailable',
+	Unauthorized = "unauthorized",
+	RestrictedResource = "restricted_resource",
+	ObjectNotFound = "object_not_found",
+	RateLimited = "rate_limited",
+	InvalidJSON = "invalid_json",
+	InvalidRequestURL = "invalid_request_url",
+	InvalidRequest = "invalid_request",
+	ValidationError = "validation_error",
+	ConflictError = "conflict_error",
+	InternalServerError = "internal_server_error",
+	ServiceUnavailable = "service_unavailable",
 }
 
 /**
  * Body of an error response from the API.
  */
 interface APIErrorResponseBody {
-  code: APIErrorCode;
-  message: string;
+	code: APIErrorCode
+	message: string
 }
 
 /**
@@ -77,63 +81,72 @@ interface APIErrorResponseBody {
  *
  * Use the `code` property to handle various kinds of errors. All its possible values are in `APIErrorCode`.
  */
-export class APIResponseError extends HTTPResponseError implements APIErrorResponseBody {
-  readonly code: APIErrorCode;
+export class APIResponseError
+	extends HTTPResponseError
+	implements APIErrorResponseBody
+{
+	readonly code: APIErrorCode
 
-  constructor(response: GotResponse, body: APIErrorResponseBody) {
-    console.log('building the error');
-    super(response, body.message);
-    this.name = 'APIResponseError';
-    this.code = body.code;
-  }
+	constructor(response: GotResponse, body: APIErrorResponseBody) {
+		console.log("building the error")
+		super(response, body.message)
+		this.name = "APIResponseError"
+		this.code = body.code
+	}
 
-  static isAPIResponseError(error: unknown): error is APIResponseError {
-    return (
-      error instanceof Error &&
-      error.name === 'APIResponseError' &&
-      'code' in error && isAPIErrorCode(error['code'])
-    );
-  }
+	static isAPIResponseError(error: unknown): error is APIResponseError {
+		return (
+			error instanceof Error &&
+			error.name === "APIResponseError" &&
+			"code" in error &&
+			isAPIErrorCode(error["code"])
+		)
+	}
 }
 
-
-type RequestError = RequestTimeoutError | HTTPResponseError;
+type RequestError = RequestTimeoutError | HTTPResponseError
 
 export function buildRequestError(error: unknown): RequestError | undefined {
-  if (isGotTimeoutError(error)) {
-    return new RequestTimeoutError();
-  }
-  if (isGotHTTPError(error)) {
-    const apiErrorResponseBody = parseAPIErrorResponseBody(error.response.body);
-    if (apiErrorResponseBody !== undefined) {
-      return new APIResponseError(error.response, apiErrorResponseBody);
-    }
-    return new HTTPResponseError(error.response);
-  }
-  return;
+	if (isGotTimeoutError(error)) {
+		return new RequestTimeoutError()
+	}
+	if (isGotHTTPError(error)) {
+		const apiErrorResponseBody = parseAPIErrorResponseBody(error.response.body)
+		if (apiErrorResponseBody !== undefined) {
+			return new APIResponseError(error.response, apiErrorResponseBody)
+		}
+		return new HTTPResponseError(error.response)
+	}
+	return
 }
 
-function parseAPIErrorResponseBody(body: unknown): APIErrorResponseBody | undefined {
-  if (typeof body !== 'string') {
-    return;
-  }
+function parseAPIErrorResponseBody(
+	body: unknown
+): APIErrorResponseBody | undefined {
+	if (typeof body !== "string") {
+		return
+	}
 
-  let parsed;
-  try {
-    parsed = JSON.parse(body);
-  } catch (parseError) {
-    return;
-  }
+	let parsed
+	try {
+		parsed = JSON.parse(body)
+	} catch (parseError) {
+		return
+	}
 
-  if (!isObject(parsed) || typeof parsed['message'] !== 'string' || !isAPIErrorCode(parsed['code'])) {
-    return;
-  }
+	if (
+		!isObject(parsed) ||
+		typeof parsed["message"] !== "string" ||
+		!isAPIErrorCode(parsed["code"])
+	) {
+		return
+	}
 
-  return {
-    ...parsed,
-    code: parsed['code'],
-    message: parsed['message'],
-  };
+	return {
+		...parsed,
+		code: parsed["code"],
+		message: parsed["message"],
+	}
 }
 
 /*
@@ -141,25 +154,32 @@ function parseAPIErrorResponseBody(body: unknown): APIErrorResponseBody | undefi
  */
 
 function isAPIErrorCode(code: unknown): code is APIErrorCode {
-  return typeof code === 'string' && Object.values<string>(APIErrorCode).includes(code);
+	return (
+		typeof code === "string" &&
+		Object.values<string>(APIErrorCode).includes(code)
+	)
 }
 
 function isGotTimeoutError(error: unknown): error is GotTimeoutError {
-  return (
-    error instanceof Error &&
-    error.name === 'TimeoutError' &&
-    'event' in error && typeof error['event'] === 'string' &&
-    isObject(error['request']) &&
-    isObject(error['timings'])
-  );
+	return (
+		error instanceof Error &&
+		error.name === "TimeoutError" &&
+		"event" in error &&
+		typeof error["event"] === "string" &&
+		isObject(error["request"]) &&
+		isObject(error["timings"])
+	)
 }
 
 function isGotHTTPError(error: unknown): error is GotHTTPError {
-  return (
-    error instanceof Error &&
-    error.name === 'HTTPError' &&
-    'request' in error && isObject(error['request']) &&
-    'response' in error && isObject(error['response']) &&
-    'timings' in error && isObject(error['timings'])
-  );
+	return (
+		error instanceof Error &&
+		error.name === "HTTPError" &&
+		"request" in error &&
+		isObject(error["request"]) &&
+		"response" in error &&
+		isObject(error["response"]) &&
+		"timings" in error &&
+		isObject(error["timings"])
+	)
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,3 @@
-
 /**
  * Utility for enforcing exhaustiveness checks in the type system.
  *
@@ -6,16 +5,19 @@
  *
  * @param _x The variable with no remaining values
  */
-export function assertNever(_x: never): never { // eslint-disable-line @typescript-eslint/no-unused-vars
-  throw new Error('Unexpected value. Should have been never.');
+export function assertNever(_x: never): never {
+	// eslint-disable-line @typescript-eslint/no-unused-vars
+	throw new Error("Unexpected value. Should have been never.")
 }
 
-
-export function pick<O extends unknown, K extends keyof O> (base: O, keys: readonly K[]): Pick<O, K> {
-  const entries = keys.map(key => ([key, base?.[key]]));
-  return Object.fromEntries(entries);
+export function pick<O extends unknown, K extends keyof O>(
+	base: O,
+	keys: readonly K[]
+): Pick<O, K> {
+	const entries = keys.map(key => [key, base?.[key]])
+	return Object.fromEntries(entries)
 }
 
 export function isObject(o: unknown): o is Record<PropertyKey, unknown> {
-  return typeof o === 'object' && o !== null;
+	return typeof o === "object" && o !== null
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,7 +6,6 @@
  * @param _x The variable with no remaining values
  */
 export function assertNever(_x: never): never {
-	// eslint-disable-line @typescript-eslint/no-unused-vars
 	throw new Error("Unexpected value. Should have been never.")
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
-export { default as Client } from './Client';
-export { LogLevel, Logger } from './logging'
-export { APIErrorCode, APIResponseError, HTTPResponseError, RequestTimeoutError } from './errors';
+export { default as Client } from "./Client"
+export { LogLevel, Logger } from "./logging"
+export {
+	APIErrorCode,
+	APIResponseError,
+	HTTPResponseError,
+	RequestTimeoutError,
+} from "./errors"

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,31 +1,36 @@
-import { assertNever } from './helpers';
+import { assertNever } from "./helpers"
 
 export enum LogLevel {
-  DEBUG = 'debug',
-  INFO = 'info',
-  WARN = 'warn',
-  ERROR = 'error',
+	DEBUG = "debug",
+	INFO = "info",
+	WARN = "warn",
+	ERROR = "error",
 }
 
 export interface Logger {
-  (level: LogLevel, message: string, extraInfo: Record<string, unknown>): void;
+	(level: LogLevel, message: string, extraInfo: Record<string, unknown>): void
 }
 
 export function makeConsoleLogger(name: string): Logger {
-  return (level, message, extraInfo) => {
-    console[level](`${name} ${level}:`, message, extraInfo);
-  };
+	return (level, message, extraInfo) => {
+		console[level](`${name} ${level}:`, message, extraInfo)
+	}
 }
 
 /**
  * Transforms a log level into a comparable (numerical) value ordered by severity.
  */
 export function logLevelSeverity(level: LogLevel): number {
-  switch (level) {
-    case LogLevel.DEBUG: return 20;
-    case LogLevel.INFO: return 40;
-    case LogLevel.WARN: return 60;
-    case LogLevel.ERROR: return 80;
-    default: return assertNever(level);
-  }
+	switch (level) {
+		case LogLevel.DEBUG:
+			return 20
+		case LogLevel.INFO:
+			return 40
+		case LogLevel.WARN:
+			return 60
+		case LogLevel.ERROR:
+			return 80
+		default:
+			return assertNever(level)
+	}
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -13,6 +13,7 @@ export interface Logger {
 
 export function makeConsoleLogger(name: string): Logger {
 	return (level, message, extraInfo) => {
+		// eslint-disable-next-line no-console
 		console[level](`${name} ${level}:`, message, extraInfo)
 	}
 }

--- a/test/client-basics.ts
+++ b/test/client-basics.ts
@@ -1,7 +1,7 @@
-import test from 'ava';
-import { Client } from '../src';
+import test from "ava"
+import { Client } from "../src"
 
-test('initialize client', t => {
-  new Client({ auth: 'foo' });
-  t.pass();
-});
+test("initialize client", t => {
+	new Client({ auth: "foo" })
+	t.pass()
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,42 +1,39 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-    // Recommended Node options have been incorporated from https://github.com/tsconfig/bases/blob/master/bases/node14.json
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig.json to read more about this file */
+		// Recommended Node options have been incorporated from https://github.com/tsconfig/bases/blob/master/bases/node14.json
 
-    // Node LTS Fermium (14.x) has mostly complete support for ES2019 (as reported by https://node.green/)
-    "target": "ES2019",
-    "module": "commonjs",
-    // "esModuleInterop": true,
+		// Node LTS Fermium (14.x) has mostly complete support for ES2019 (as reported by https://node.green/)
+		"target": "ES2019",
+		"module": "commonjs",
+		// "esModuleInterop": true,
 
-    // Overrides default in order to remove "dom" because this package shouldn't assume the presence of browser APIs
-    "lib": ["ES2019"],
+		// Overrides default in order to remove "dom" because this package shouldn't assume the presence of browser APIs
+		"lib": ["ES2019"],
 
-    // Emit location
-    "outDir": "build",
+		// Emit location
+		"outDir": "build",
 
-    // Emit sourcemaps
-    "declarationMap": true,
-    "sourceMap": true,
-    "inlineSources": true,
+		// Emit sourcemaps
+		"declarationMap": true,
+		"sourceMap": true,
+		"inlineSources": true,
 
-    // Emit type definitions
-    "declaration": true,
+		// Emit type definitions
+		"declaration": true,
 
-    // Strict mode
-    "strict": true,
+		// Strict mode
+		"strict": true,
 
-    // Linter style rules
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "forceConsistentCasingInFileNames": true,
-  },
+		// Linter style rules
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"forceConsistentCasingInFileNames": true
+	},
 
-  "include": [
-    "src/**/*",
-    "test/**/*",
-  ],
+	"include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
This is a small set of style changes to the notion api example code

- more obviously calls out the use of the notion API, so it jumps out when looking at the glitch examples
- import internal notion .prettierrc, reformat the repo - it had a lot of non-idiomatic spacing like Client({auth:process.env.NOTION_KEY})
- fix comments to have a space between comment chars and text
- lower required node version to 12.21 to keep parity with internal notion development, also, code runs fine on node 12