### PR TITLE
lower node engine to >=12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "@notionhq/client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=12"
   },
-  "keywords": ["notion", "notionapi", "rest", "notion-api"],
+  "keywords": [
+    "notion",
+    "notionapi",
+    "rest",
+    "notion-api"
+  ],
   "main": "./build/src",
   "scripts": {
     "prepare": "npm run build",
@@ -15,7 +20,9 @@
   },
   "author": "",
   "license": "MIT",
-  "files": ["build/src/**"],
+  "files": [
+    "build/src/**"
+  ],
   "dependencies": {
     "got": "^11.8.2"
   },


### PR DESCRIPTION
This adds a warning in npm install for ava@typescript that can be safely ignored