### PR TITLE
clean output directory "build" before building

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "main": "./build/src",
   "scripts": {
     "prepare": "npm run build",
+    "prebuild": "npm run clean",
     "build": "tsc",
+    "clean": "rimraf ./build/",
     "lint": "eslint . --ext .ts",
     "test": "ava"
   },
@@ -25,6 +27,7 @@
     "@typescript-eslint/parser": "^4.22.0",
     "ava": "^3.15.0",
     "eslint": "^7.24.0",
+    "rimraf": "^3.0.2",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
Everytime a build is created, the output directory "build" should be cleaned.
This prevents from uncesessary/deleted files from last build and also helpful during development.
