### PR TITLE
Rework error types, remove got in favor of node-fetch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,8 +17,10 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": [
       "error",
       {
-        args: "none",
+        args: "all",
         argsIgnorePattern: "^_",
+        // Allow assertion types.
+        varsIgnorePattern: "^_assert",
         caughtErrors: "none",
         ignoreRestSiblings: true,
       },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run build --if-present
+      - run: npm run build
       - run: npm run lint
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -143,7 +143,11 @@ The `Client` supports the following options on initialization. These options are
 
 This package contains type definitions for **all request parameters and responses**.
 
-Error classes, such as `RequestTimeoutError` and `APIResponseError`, contain type guards as static methods which can be useful for narrowing the type of a thrown error. TypeScript infers all thrown errors to be `any` or `unknown`. These type guards will allow you to handle errors with better type support.
+Because errors in TypeScript start with type `any` or `unknown`, you should use
+the `isNotionClientError` type guard to handle them in a type-safe way. Each
+`NotionClientError` type is uniquely identified by its `error.code`. Codes in
+the `APIErrorCode` enum are returned from the server. Codes in the
+`ClientErrorCode` enum are produced on the client.
 
 ```ts
 try {
@@ -151,9 +155,12 @@ try {
     /* ... */
   })
 } catch (error: unknown) {
-  if (APIResponseError.isAPIResponseError(error)) {
-    // error is now strongly typed to APIResponseError
+  if (isNotionClientError(error)) {
+    // error is now strongly typed to NotionClientError
     switch (error.code) {
+      case ClientErrorCode.RequestTimeout:
+        // ...
+        break
       case APIErrorCode.ObjectNotFound:
         // ...
         break

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build/src/**"
   ],
   "dependencies": {
-    "node-fetch": "^2.6.1"
+    "cross-fetch": "^3.1.4"
   },
   "devDependencies": {
     "@ava/typescript": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "build/src/**"
   ],
   "dependencies": {
-    "cross-fetch": "^3.1.4"
+    "@types/node-fetch": "^2.5.10",
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@ava/typescript": "^2.0.0",
-    "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "ava": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "author": "",
   "license": "MIT",
   "files": [
+    "build/package.json",
     "build/src/**"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@ava/typescript": "^2.0.0",
+    "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "ava": "^3.15.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build/src/**"
   ],
   "dependencies": {
-    "got": "^11.8.2"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@ava/typescript": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "main": "./build/src",
   "scripts": {
-    "prepare": "npm run lint && npm run build",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run lint && npm run test",
     "build": "tsc",
     "prettier": "prettier --write .",
     "lint": "prettier --check . && eslint . --ext .ts && cspell '**/*' ",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -48,7 +48,10 @@ import {
   search,
 } from "./api-endpoints"
 import crossFetch from "cross-fetch"
-import { version as PACKAGE_VERSION } from "../package.json"
+import {
+  version as PACKAGE_VERSION,
+  name as PACKAGE_NAME,
+} from "../package.json"
 import { CrossResponse, SupportedFetch } from "./fetch-types"
 
 export interface ClientOptions {
@@ -87,7 +90,7 @@ export default class Client {
   public constructor(options?: ClientOptions) {
     this.#auth = options?.auth
     this.#logLevel = options?.logLevel ?? LogLevel.WARN
-    this.#logger = options?.logger ?? makeConsoleLogger(this.constructor.name)
+    this.#logger = options?.logger ?? makeConsoleLogger(PACKAGE_NAME)
     this.#prefixUrl = (options?.baseUrl ?? "https://api.notion.com") + "/v1/"
     this.#timeoutMs = options?.timeoutMs ?? 60_000
     this.#notionVersion = options?.notionVersion ?? Client.defaultNotionVersion

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,5 +1,4 @@
 import type { Agent } from "http"
-import { URL } from "url"
 import {
   Logger,
   LogLevel,
@@ -117,14 +116,16 @@ export default class Client {
 
     // If the body is empty, don't send the body in the HTTP request
     const bodyAsJsonString =
-      body !== undefined && Object.entries(body).length === 0
+      !body || Object.entries(body).length === 0
         ? undefined
         : JSON.stringify(body)
 
     const url = new URL(`${this.#prefixUrl}${path}`)
     if (query) {
       for (const [key, value] of Object.entries(query)) {
-        url.searchParams.append(key, String(value))
+        if (value !== undefined) {
+          url.searchParams.append(key, String(value))
+        }
       }
     }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -397,9 +397,6 @@ export default class Client {
   }
 }
 
-const u = new URL("https://example.com")
-u.searchParams.append
-
 /*
  * Type aliases to support the generic request interface.
  */

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -6,7 +6,12 @@ import {
   logLevelSeverity,
   makeConsoleLogger,
 } from "./logging"
-import { buildRequestError, HTTPResponseError } from "./errors"
+import {
+  buildRequestError,
+  HTTPResponseError,
+  isNotionClientError,
+  RequestTimeoutError,
+} from "./errors"
 import { pick } from "./helpers"
 import {
   BlocksChildrenAppendParameters,
@@ -43,13 +48,9 @@ import {
   SearchResponse,
   search,
 } from "./api-endpoints"
-
-import got, {
-  Got,
-  Options as GotOptions,
-  Headers as GotHeaders,
-  Agents as GotAgents,
-} from "got"
+import crossFetch from "cross-fetch"
+import { version as PACKAGE_VERSION } from "../package.json"
+import { CrossResponse, SupportedFetch } from "./fetch-types"
 
 export interface ClientOptions {
   auth?: string
@@ -57,8 +58,10 @@ export interface ClientOptions {
   baseUrl?: string
   logLevel?: LogLevel
   logger?: Logger
-  agent?: Agent
   notionVersion?: string
+  fetch?: SupportedFetch
+  /** Silently ignored in the browser */
+  agent?: Agent
 }
 
 export interface RequestParameters {
@@ -73,7 +76,11 @@ export default class Client {
   #auth?: string
   #logLevel: LogLevel
   #logger: Logger
-  #got: Got
+  #prefixUrl: string
+  #timeout: number
+  #notionVersion: string
+  #fetch: SupportedFetch
+  #userAgent: string
 
   static readonly defaultNotionVersion = "2021-05-13"
 
@@ -81,22 +88,11 @@ export default class Client {
     this.#auth = options?.auth
     this.#logLevel = options?.logLevel ?? LogLevel.WARN
     this.#logger = options?.logger ?? makeConsoleLogger(this.constructor.name)
-
-    const prefixUrl = (options?.baseUrl ?? "https://api.notion.com") + "/v1/"
-    const timeout = options?.timeoutMs ?? 60_000
-    const notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
-
-    this.#got = got.extend({
-      prefixUrl,
-      timeout,
-      headers: {
-        "Notion-Version": notionVersion,
-        // TODO: update with format appropriate for telemetry, use version from package.json
-        "user-agent": "notionhq-client/0.1.0",
-      },
-      retry: 0,
-      agent: makeAgentOption(prefixUrl, options?.agent),
-    })
+    this.#prefixUrl = (options?.baseUrl ?? "https://api.notion.com") + "/v1/"
+    this.#timeout = options?.timeoutMs ?? 60_000
+    this.#notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
+    this.#fetch = options?.fetch ?? crossFetch
+    this.#userAgent = `notionhq-client/${PACKAGE_VERSION}`
   }
 
   /**
@@ -108,49 +104,83 @@ export default class Client {
    * @param body
    * @returns
    */
-  public async request<Response>({
+  public async request<ResponseBody>({
     path,
     method,
     query,
     body,
     auth,
-  }: RequestParameters): Promise<Response> {
+  }: RequestParameters): Promise<ResponseBody> {
     this.log(LogLevel.INFO, "request start", { method, path })
 
     // If the body is empty, don't send the body in the HTTP request
-    const json =
-      body !== undefined && Object.entries(body).length === 0 ? undefined : body
+    const bodyAsJsonString =
+      body !== undefined && Object.entries(body).length === 0
+        ? undefined
+        : JSON.stringify(body)
 
+    const url = new URL(`${this.#prefixUrl}${path}`)
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        url.searchParams.append(key, String(value))
+      }
+    }
+
+    const headers: Record<string, string> = {
+      ...this.authAsHeaders(auth),
+      "Notion-Version": this.#notionVersion,
+      "user-agent": this.#userAgent,
+    }
+
+    if (bodyAsJsonString !== undefined) {
+      headers["content-type"] = "application/json"
+    }
     try {
-      const response = await this.#got(path, {
-        method,
-        searchParams: query,
-        json,
-        headers: this.authAsHeaders(auth),
-      }).json<Response>()
+      const response = await new Promise<CrossResponse>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          // TODO: log?
+          reject(new RequestTimeoutError())
+        }, this.#timeout)
 
+        this.#fetch(url.toString(), {
+          method,
+          headers,
+          body: bodyAsJsonString,
+        })
+          .then(resolve)
+          .catch(reject)
+          .then(() => clearTimeout(timeoutId))
+      })
+
+      const responseText = await response.text()
+      if (!response.ok) {
+        const error = buildRequestError(response, responseText)
+        if (error) {
+          throw error
+        }
+      }
+
+      const responseJson: ResponseBody = JSON.parse(responseText)
       this.log(LogLevel.INFO, `request success`, { method, path })
-      return response
-    } catch (error) {
-      // Build an error of a known type, otherwise throw unexpected errors
-      const requestError = buildRequestError(error)
-      if (requestError === undefined) {
+      return responseJson
+    } catch (error: unknown) {
+      if (!isNotionClientError(error)) {
         throw error
       }
 
+      // Log the error if it's one of our known error types
       this.log(LogLevel.WARN, `request fail`, {
-        code: requestError.code,
-        message: requestError.message,
+        code: error.code,
+        message: error.message,
       })
-      if (HTTPResponseError.isHTTPResponseError(requestError)) {
+      if (HTTPResponseError.isHTTPResponseError(error)) {
         // The response body may contain sensitive information so it is logged separately at the DEBUG level
         this.log(LogLevel.DEBUG, `failed response body`, {
-          body: requestError.body,
+          body: error.body,
         })
       }
 
-      // Throw as a known error type
-      throw requestError
+      throw error
     }
   }
 
@@ -358,8 +388,8 @@ export default class Client {
    * @param auth API key or access token
    * @returns headers key-value object
    */
-  private authAsHeaders(auth?: string): GotHeaders {
-    const headers: GotHeaders = {}
+  private authAsHeaders(auth?: string): Record<string, string> {
+    const headers: Record<string, string> = {}
     const authHeaderValue = auth ?? this.#auth
     if (authHeaderValue !== undefined) {
       headers["authorization"] = `Bearer ${authHeaderValue}`
@@ -368,38 +398,13 @@ export default class Client {
   }
 }
 
+const u = new URL("https://example.com")
+u.searchParams.append
+
 /*
  * Type aliases to support the generic request interface.
  */
 type Method = "get" | "post" | "patch"
-type QueryParams = GotOptions["searchParams"]
+type QueryParams = Record<string, string | number> | URLSearchParams
 
 type WithAuth<P> = P & { auth?: string }
-
-/*
- * Helper functions
- */
-
-function makeAgentOption(
-  prefixUrl: string,
-  agent: Agent | undefined
-): GotAgents | undefined {
-  if (agent === undefined) {
-    return undefined
-  }
-  return {
-    [selectProtocol(prefixUrl)]: agent,
-  }
-}
-
-function selectProtocol(prefixUrl: string): "http" | "https" {
-  const url = new URL(prefixUrl)
-
-  if (url.protocol === "https:") {
-    return "https"
-  } else if (url.protocol === "http:") {
-    return "http"
-  }
-
-  throw new TypeError(`baseUrl option must begin with "https://" or "http://"`)
-}

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -138,7 +138,6 @@ export default class Client {
     try {
       const response = await new Promise<CrossResponse>((resolve, reject) => {
         const timeoutId = setTimeout(() => {
-          // TODO: log?
           reject(new RequestTimeoutError())
         }, this.#timeout)
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -8,7 +8,7 @@ import {
 } from "./logging"
 import {
   buildRequestError,
-  HTTPResponseError,
+  isHTTPResponseError,
   isNotionClientError,
   RequestTimeoutError,
 } from "./errors"
@@ -156,10 +156,7 @@ export default class Client {
 
       const responseText = await response.text()
       if (!response.ok) {
-        const error = buildRequestError(response, responseText)
-        if (error) {
-          throw error
-        }
+        throw buildRequestError(response, responseText)
       }
 
       const responseJson: ResponseBody = JSON.parse(responseText)
@@ -175,7 +172,8 @@ export default class Client {
         code: error.code,
         message: error.message,
       })
-      if (HTTPResponseError.isHTTPResponseError(error)) {
+
+      if (isHTTPResponseError(error)) {
         // The response body may contain sensitive information so it is logged separately at the DEBUG level
         this.log(LogLevel.DEBUG, `failed response body`, {
           body: error.body,

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -80,6 +80,7 @@ export default class Client {
   #timeout: number
   #notionVersion: string
   #fetch: SupportedFetch
+  #agent: Agent | undefined
   #userAgent: string
 
   static readonly defaultNotionVersion = "2021-05-13"
@@ -92,6 +93,7 @@ export default class Client {
     this.#timeout = options?.timeoutMs ?? 60_000
     this.#notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
     this.#fetch = options?.fetch ?? crossFetch
+    this.#agent = options?.agent
     this.#userAgent = `notionhq-client/${PACKAGE_VERSION}`
   }
 
@@ -145,6 +147,7 @@ export default class Client {
           method,
           headers,
           body: bodyAsJsonString,
+          agent: this.#agent,
         })
           .then(resolve)
           .catch(reject)

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -47,7 +47,7 @@ import {
   SearchResponse,
   search,
 } from "./api-endpoints"
-import crossFetch from "cross-fetch"
+import nodeFetch from "node-fetch"
 import {
   version as PACKAGE_VERSION,
   name as PACKAGE_NAME,
@@ -94,7 +94,7 @@ export default class Client {
     this.#prefixUrl = (options?.baseUrl ?? "https://api.notion.com") + "/v1/"
     this.#timeoutMs = options?.timeoutMs ?? 60_000
     this.#notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
-    this.#fetch = options?.fetch ?? crossFetch
+    this.#fetch = options?.fetch ?? nodeFetch
     this.#agent = options?.agent
     this.#userAgent = `notionhq-client/${PACKAGE_VERSION}`
   }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -52,7 +52,7 @@ import {
   version as PACKAGE_VERSION,
   name as PACKAGE_NAME,
 } from "../package.json"
-import { CrossResponse, SupportedFetch } from "./fetch-types"
+import { SupportedFetch } from "./fetch-types"
 
 export interface ClientOptions {
   auth?: string

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -27,7 +27,7 @@ export enum ClientErrorCode {
 }
 
 /**
- * Error codes on errors thrown by the [[Client]].
+ * Error codes on errors thrown by the `Client`.
  */
 export type NotionErrorCode = APIErrorCode | ClientErrorCode
 
@@ -82,6 +82,9 @@ export function isNotionClientErrorWithCode<Code extends NotionErrorCode>(
   return isNotionClientError(error) && error.code in codes
 }
 
+/**
+ * Error thrown by the client if a request times out.
+ */
 export class RequestTimeoutError extends NotionClientErrorBase<ClientErrorCode.RequestTimeout> {
   readonly code = ClientErrorCode.RequestTimeout
   readonly name = "RequestTimeoutError"
@@ -150,6 +153,7 @@ export function isHTTPResponseError(
     UnknownHTTPResponseError | APIResponseError,
     typeof error
   >
+
   return true
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -41,7 +41,7 @@ abstract class NotionClientErrorBase<
 }
 
 /**
- * Error type that encompases all the kinds of errors that the Notion client will throw.
+ * Error type that encompasses all the kinds of errors that the Notion client will throw.
  */
 export type NotionClientError =
   | RequestTimeoutError

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,6 @@
 import { CrossResponse } from "./fetch-types"
-import { Assert, isObject } from "./helpers"
+import { isObject } from "./helpers"
+import { Assert } from "./type-utils"
 
 /**
  * Error codes returned in responses from the API.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -76,7 +76,7 @@ export function isNotionClientError(
  * @param codes an object mapping from possible error codes to `true`
  * @returns `true` if error is a `NotionClientError` with a code in `codes`.
  */
-export function isNotionClientErrorWithCode<Code extends NotionErrorCode>(
+function isNotionClientErrorWithCode<Code extends NotionErrorCode>(
   error: unknown,
   codes: { [C in Code]: true }
 ): error is NotionClientError & { code: Code } {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { CrossResponse } from "./fetch-types"
+import { SupportedResponse } from "./fetch-types"
 import { isObject } from "./helpers"
 import { Assert } from "./type-utils"
 
@@ -125,14 +125,14 @@ class HTTPResponseError<
   readonly name: string = "HTTPResponseError"
   readonly code: Code
   readonly status: number
-  readonly headers: Headers
+  readonly headers: SupportedResponse["headers"]
   readonly body: string
 
   constructor(args: {
     code: Code
     status: number
     message: string
-    headers: CrossResponse["headers"]
+    headers: SupportedResponse["headers"]
     rawBodyText: string
   }) {
     super(args.message)
@@ -184,7 +184,7 @@ export class UnknownHTTPResponseError extends HTTPResponseError<ClientErrorCode.
   constructor(args: {
     status: number
     message: string | undefined
-    headers: CrossResponse["headers"]
+    headers: SupportedResponse["headers"]
     rawBodyText: string
   }) {
     super({
@@ -232,7 +232,7 @@ export class APIResponseError extends HTTPResponseError<APIErrorCode> {
 }
 
 export function buildRequestError(
-  response: CrossResponse,
+  response: SupportedResponse,
   bodyText: string
 ): APIResponseError | UnknownHTTPResponseError {
   const apiErrorResponseBody = parseAPIErrorResponseBody(bodyText)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -99,6 +99,22 @@ export class RequestTimeoutError extends NotionClientErrorBase<ClientErrorCode.R
       [ClientErrorCode.RequestTimeout]: true,
     })
   }
+
+  static rejectAfterTimeout<T>(
+    promise: Promise<T>,
+    timeoutMS: number
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new RequestTimeoutError())
+      }, timeoutMS)
+
+      promise
+        .then(resolve)
+        .catch(reject)
+        .then(() => clearTimeout(timeoutId))
+    })
+  }
 }
 
 type HTTPResponseErrorCode = ClientErrorCode.ResponseError | APIErrorCode

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,67 +1,6 @@
 import { CrossResponse } from "./fetch-types"
 import { isObject } from "./helpers"
 
-// Root type
-class NotionClientErrorBase extends Error {}
-
-export type NotionClientError =
-  | RequestTimeoutError
-  | HTTPResponseError
-  | APIResponseError
-export function isNotionClientError(
-  error: unknown
-): error is NotionClientError {
-  return error instanceof NotionClientErrorBase
-}
-
-export class RequestTimeoutError extends NotionClientErrorBase {
-  readonly code = "notionhq_client_request_timeout"
-
-  constructor(message = "Request to Notion API has timed out") {
-    super(message)
-    this.name = "RequestTimeoutError"
-  }
-
-  static isRequestTimeoutError(error: unknown): error is RequestTimeoutError {
-    return (
-      error instanceof Error &&
-      error.name === "RequestTimeoutError" &&
-      "code" in error &&
-      error["code"] === RequestTimeoutError.prototype.code
-    )
-  }
-}
-
-export class HTTPResponseError extends NotionClientErrorBase {
-  readonly code: string = "notionhq_client_response_error"
-  readonly status: number
-  readonly headers: Headers
-  readonly body: string
-
-  constructor(
-    response: CrossResponse,
-    message: string | undefined,
-    rawBodyText: string
-  ) {
-    super(
-      message ?? `Request to Notion API failed with status: ${response.status}`
-    )
-    this.name = "HTTPResponseError"
-    this.status = response.status
-    this.headers = response.headers
-    this.body = rawBodyText
-  }
-
-  static isHTTPResponseError(error: unknown): error is HTTPResponseError {
-    return (
-      error instanceof Error &&
-      error.name === "HTTPResponseError" &&
-      "code" in error &&
-      error["code"] === HTTPResponseError.prototype.code
-    )
-  }
-}
-
 /**
  * Error codes for responses from the API.
  */
@@ -80,11 +19,111 @@ export enum APIErrorCode {
 }
 
 /**
- * Body of an error response from the API.
+ * Error codes generated for client errors.
  */
-interface APIErrorResponseBody {
-  code: APIErrorCode
-  message: string
+export enum ClientErrorCode {
+  RequestTimeout = "notionhq_client_request_timeout",
+  ResponseError = "notionhq_client_response_error",
+}
+
+/**
+ * Error codes on errors thrown by the Client.
+ */
+export type NotionErrorCode = APIErrorCode | ClientErrorCode
+
+/**
+ * Base error type.
+ */
+abstract class NotionClientErrorBase<
+  Code extends NotionErrorCode
+> extends Error {
+  abstract code: Code
+}
+
+/**
+ * Error type that encompases all the kinds of errors that the Notion client will throw.
+ */
+export type NotionClientError =
+  | RequestTimeoutError
+  | UnknownHTTPResponseError
+  | APIResponseError
+
+export function isNotionClientError(
+  error: unknown
+): error is NotionClientError {
+  return isObject(error) && error instanceof NotionClientErrorBase
+}
+
+export function isHTTPResponseError(
+  error: unknown
+): error is UnknownHTTPResponseError | APIResponseError {
+  if (!isNotionClientError(error)) {
+    return false
+  }
+  return (
+    error.code === ClientErrorCode.ResponseError || isAPIErrorCode(error.code)
+  )
+}
+
+export class RequestTimeoutError extends NotionClientErrorBase<ClientErrorCode.RequestTimeout> {
+  readonly code = ClientErrorCode.RequestTimeout
+  readonly name = "RequestTimeoutError"
+
+  constructor(message = "Request to Notion API has timed out") {
+    super(message)
+  }
+
+  static isRequestTimeoutError(error: unknown): error is RequestTimeoutError {
+    return (
+      error instanceof Error &&
+      error.name === "RequestTimeoutError" &&
+      "code" in error &&
+      error["code"] === RequestTimeoutError.prototype.code
+    )
+  }
+}
+
+class HTTPResponseError<
+  Code extends ClientErrorCode.ResponseError | APIErrorCode
+> extends NotionClientErrorBase<Code> {
+  readonly name: string = "HTTPResponseError"
+  readonly code: Code
+  readonly status: number
+  readonly headers: Headers
+  readonly body: string
+
+  constructor(args: {
+    code: Code
+    status: number
+    message: string
+    headers: CrossResponse["headers"]
+    rawBodyText: string
+  }) {
+    super(args.message)
+    const { code, status, headers, rawBodyText } = args
+    this.code = code
+    this.status = status
+    this.headers = headers
+    this.body = rawBodyText
+  }
+}
+
+export class UnknownHTTPResponseError extends HTTPResponseError<ClientErrorCode.ResponseError> {
+  readonly name = "UnkownHTTPResponseError"
+  constructor(args: {
+    status: number
+    message: string | undefined
+    headers: CrossResponse["headers"]
+    rawBodyText: string
+  }) {
+    super({
+      ...args,
+      code: ClientErrorCode.ResponseError,
+      message:
+        args.message ??
+        `Request to Notion API failed with status: ${args.status}`,
+    })
+  }
 }
 
 /**
@@ -92,21 +131,8 @@ interface APIErrorResponseBody {
  *
  * Use the `code` property to handle various kinds of errors. All its possible values are in `APIErrorCode`.
  */
-export class APIResponseError
-  extends HTTPResponseError
-  implements APIErrorResponseBody
-{
-  readonly code: APIErrorCode
-
-  constructor(
-    response: CrossResponse,
-    body: APIErrorResponseBody,
-    rawBodyText: string
-  ) {
-    super(response, body.message, rawBodyText)
-    this.name = "APIResponseError"
-    this.code = body.code
-  }
+export class APIResponseError extends HTTPResponseError<APIErrorCode> {
+  readonly name = "APIResponseError"
 
   static isAPIResponseError(error: unknown): error is APIResponseError {
     return (
@@ -121,22 +147,33 @@ export class APIResponseError
 export function buildRequestError(
   response: CrossResponse,
   bodyText: string
-): APIResponseError | HTTPResponseError | undefined {
+): APIResponseError | UnknownHTTPResponseError {
   const apiErrorResponseBody = parseAPIErrorResponseBody(bodyText)
   if (apiErrorResponseBody !== undefined) {
-    return new APIResponseError(response, apiErrorResponseBody, bodyText)
+    return new APIResponseError({
+      code: apiErrorResponseBody.code,
+      message: apiErrorResponseBody.message,
+      headers: response.headers,
+      status: response.status,
+      rawBodyText: bodyText,
+    })
   }
-  return new HTTPResponseError(response, undefined, bodyText)
+  return new UnknownHTTPResponseError({
+    message: undefined,
+    headers: response.headers,
+    status: response.status,
+    rawBodyText: bodyText,
+  })
 }
 
 function parseAPIErrorResponseBody(
-  body: unknown
-): APIErrorResponseBody | undefined {
+  body: string
+): { code: APIErrorCode; message: string } | undefined {
   if (typeof body !== "string") {
     return
   }
 
-  let parsed
+  let parsed: unknown
   try {
     parsed = JSON.parse(body)
   } catch (parseError) {

--- a/src/fetch-types.ts
+++ b/src/fetch-types.ts
@@ -1,14 +1,31 @@
-import type crossFetch from "cross-fetch"
-import type { Await } from "./type-utils"
-import type { RequestInit as NodeRequestInit } from "node-fetch"
+/// <reference lib="dom" />
+import type { Assert, Await } from "./type-utils"
+import type {
+  RequestInit as NodeRequestInit,
+  Response as NodeResponse,
+} from "node-fetch"
 
-export type CrossRequestInfo = Parameters<typeof crossFetch>[0]
-export type CrossRequestInit = NonNullable<Parameters<typeof crossFetch>[1]>
-export type CrossResponse = Await<ReturnType<typeof crossFetch>>
+type FetchFn = typeof fetch
+type FetchResponse = Await<ReturnType<FetchFn>>
+type RequestInfo = Parameters<FetchFn>[0]
+type RequestInit = NonNullable<Parameters<FetchFn>[1]>
 
-export type SupportedRequestInit = Pick<NodeRequestInit, "agent"> &
-  Pick<CrossRequestInit, "body" | "headers" | "method" | "redirect" | "signal">
+export type SupportedRequestInfo = string
+type _assertSupportedInfoIsSubtype = Assert<RequestInfo, SupportedRequestInfo>
+
+export type SupportedRequestInit = {
+  agent?: NodeRequestInit["agent"]
+  body?: NonNullable<RequestInit["body"]> & NonNullable<NodeRequestInit["body"]>
+  headers?: NonNullable<RequestInit["headers"]> &
+    NonNullable<NodeRequestInit["headers"]>
+  method?: RequestInit["method"]
+  redirect?: RequestInit["redirect"]
+}
+type _assertSupportedInitIsSubtype = Assert<RequestInit, SupportedRequestInit>
+
+export type SupportedResponse = FetchResponse | NodeResponse
+
 export type SupportedFetch = (
-  request: CrossRequestInfo,
+  url: SupportedRequestInfo,
   init?: SupportedRequestInit
-) => Promise<CrossResponse>
+) => Promise<SupportedResponse>

--- a/src/fetch-types.ts
+++ b/src/fetch-types.ts
@@ -1,0 +1,14 @@
+import type crossFetch from "cross-fetch"
+import type { Await } from "./type-utils"
+import type { RequestInit as NodeRequestInit } from "node-fetch"
+
+export type CrossRequestInfo = Parameters<typeof crossFetch>[0]
+export type CrossRequestInit = NonNullable<Parameters<typeof crossFetch>[1]>
+export type CrossResponse = Await<ReturnType<typeof crossFetch>>
+
+export type SupportedRequestInit = Pick<NodeRequestInit, "agent"> &
+  Pick<CrossRequestInit, "body" | "headers" | "method" | "redirect" | "signal">
+export type SupportedFetch = (
+  request: CrossRequestInfo,
+  init?: SupportedRequestInit
+) => Promise<CrossResponse>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,8 +20,3 @@ export function pick<O extends unknown, K extends keyof O>(
 export function isObject(o: unknown): o is Record<PropertyKey, unknown> {
   return typeof o === "object" && o !== null
 }
-
-/**
- * Assert U is assignable to T.
- */
-export type Assert<T, U extends T> = U

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -3,10 +3,10 @@
  *
  * @see https://basarat.gitbook.io/typescript/type-system/discriminated-unions#throw-in-exhaustive-checks
  *
- * @param _x The variable with no remaining values
+ * @param value The variable with no remaining values
  */
-export function assertNever(_x: never): never {
-  throw new Error("Unexpected value. Should have been never.")
+export function assertNever(value: never): never {
+  throw new Error(`Unexpected value should never occur: ${value}`)
 }
 
 export function pick<O extends unknown, K extends keyof O>(
@@ -20,3 +20,8 @@ export function pick<O extends unknown, K extends keyof O>(
 export function isObject(o: unknown): o is Record<PropertyKey, unknown> {
   return typeof o === "object" && o !== null
 }
+
+/**
+ * Assert U is assignable to T.
+ */
+export type Assert<T, U extends T> = U

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,4 @@ export {
   RequestTimeoutError,
   // Error helpers
   isNotionClientError,
-  isNotionClientErrorWithCode,
 } from "./errors"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 export { default as Client } from "./Client"
 export { LogLevel, Logger } from "./logging"
 export {
+  // Error codes
+  NotionErrorCode,
   APIErrorCode,
+  ClientErrorCode,
+  // Error types
+  NotionClientError,
   APIResponseError,
-  HTTPResponseError,
+  UnknownHTTPResponseError,
   RequestTimeoutError,
+  // Error helpers
+  isNotionClientError,
+  isNotionClientErrorWithCode,
 } from "./errors"

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -19,3 +19,9 @@ export type DistributiveOmit<T, K extends keyof any> = T extends any
 // Given a type union, add a field to every member of it
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DistributiveExtend<T, K extends any> = T extends any ? T & K : never
+
+export type Await<T> = T extends {
+  then(onfulfilled?: (value: infer U) => unknown): unknown
+}
+  ? U
+  : T

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -20,8 +20,16 @@ export type DistributiveOmit<T, K extends keyof any> = T extends any
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DistributiveExtend<T, K extends any> = T extends any ? T & K : never
 
+/**
+ * Unwrap the type of a promise
+ */
 export type Await<T> = T extends {
   then(onfulfilled?: (value: infer U) => unknown): unknown
 }
   ? U
   : T
+
+/**
+ * Assert U is assignable to T.
+ */
+export type Assert<T, U extends T> = U

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     "resolveJsonModule": true,
 
     // Linter style rules
-    "noUnusedLocals": true,
+    "noUnusedLocals": false, // Disabled because we use eslint for this.
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
     // Strict mode
     "strict": true,
 
+    // Allow import package.json
+    "resolveJsonModule": true,
+
     // Linter style rules
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## What

- Rework error types. This is a breaking change.
- replace `got` with `node-fetch`, similar to whatwg-fetch.
- Allow pluggable `fetch` function that supports the subset of fetch options compatible with `node-fetch` & browser fetch
- use package.json version in user-agent header

## Why

- Partially addresses #60, although does not provide a solution for security or CORS.
- Because we no longer import big expensive dependencies, consumers will be able to subclass `Client` to override the `request` method to implement proxying requests via the server.

## Remarks

- This adds some new code, but also removes some got-specific code of about the same length. The trade-off seems worth it.
- I haven't tested this code yet, and unfortunately we don't have any tests for `Client.prototype.request`. Being able to inject our own `fetch` implementation should make writing tests easier
- I plan to integration test the branch by integrating it into my project https://github.com/justjake/notrition in the coming days, but don't expect rapid movement here -- I'm doing this work as a hobbyist who wants isomorphic fetch, not as a Notion employee.
