### PR TITLE
fix: update image links

### DIFF
--- a/examples/database-update-send-email/README.md
+++ b/examples/database-update-send-email/README.md
@@ -1,6 +1,6 @@
 # Sample Integration: Notion to Email
 
-<img src="https://dev.notion.com/front-static/external/readme/images/notion-email-example@2x.png" alt="drawing" width="500"/>
+<img src="https://dev.notion.so/front-static/external/readme/images/notion-email-example@2x.png" alt="drawing" width="500"/>
 
 ## About the Integration
 

--- a/examples/github-issue-sync/README.md
+++ b/examples/github-issue-sync/README.md
@@ -1,6 +1,6 @@
 # Sample Integration: GitHub Issues to Notion
 
-<img src="https://dev.notion.com/front-static/external/readme/images/github-notion-example@2x.png" alt="drawing" width="500"/>
+<img src="https://dev.notion.so/front-static/external/readme/images/github-notion-example@2x.png" alt="drawing" width="500"/>
 
 ## About the Integration
 


### PR DESCRIPTION
This PR fixes the broken readme banner images. The rest of the `notion.com` links get redirected to `notion.so` but `dev.notion.com` doesn't so these image urls still need the `.so` tld. 