### PR TITLE
Fix CI build failures

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 build
+.github/**/*.md

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "npm run lint && npm run build",
     "build": "tsc",
     "prettier": "prettier --write .",
-    "lint": "prettier --check '**/*.ts' && eslint . --ext .ts && cspell '**/*' ",
+    "lint": "prettier --check . && eslint . --ext .ts && cspell '**/*' ",
     "test": "ava",
     "check-links": "git ls-files | grep md$ | xargs -n 1 markdown-link-check",
     "prebuild": "npm run clean",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "npm run lint && npm run build",
     "build": "tsc",
     "prettier": "prettier --write .",
-    "lint": "prettier --check . && eslint . --ext .ts && cspell '**/*' ",
+    "lint": "prettier --check '**/*.ts' && eslint . --ext .ts && cspell '**/*' ",
     "test": "ava",
     "check-links": "git ls-files | grep md$ | xargs -n 1 markdown-link-check",
     "prebuild": "npm run clean",


### PR DESCRIPTION
This pull request fixes the build failure with the latest revision. The command `npm i` fails as it tries to validate the markdown files under `.github` directory.