### PR TITLE
Remove duplicate MultiSelectProperty interface

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -211,13 +211,6 @@ export interface MultiSelectProperty extends PropertyBase {
   }
 }
 
-export interface MultiSelectProperty extends PropertyBase {
-  type: "multi_select"
-  multi_select: {
-    options: MultiSelectOption[]
-  }
-}
-
 export interface DateProperty extends PropertyBase {
   type: "date"
   date: Record<string, never>


### PR DESCRIPTION
The interface is already defined right above.