### PR TITLE
Changes Block children prop type to Block[]

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 build
+.github

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -64,7 +64,7 @@ export interface ParagraphBlock extends BlockBase {
   type: "paragraph"
   paragraph: {
     text: RichText[]
-    children?: BlockBase[]
+    children?: Block[]
   }
 }
 
@@ -90,7 +90,7 @@ export interface BulletedListItemBlock extends BlockBase {
   type: "bulleted_list_item"
   bulleted_list_item: {
     text: RichText[]
-    children?: BlockBase[]
+    children?: Block[]
   }
 }
 
@@ -98,7 +98,7 @@ export interface NumberedListItemBlock extends BlockBase {
   type: "numbered_list_item"
   numbered_list_item: {
     text: RichText[]
-    children?: BlockBase[]
+    children?: Block[]
   }
 }
 
@@ -107,7 +107,7 @@ export interface ToDoBlock extends BlockBase {
   to_do: {
     text: RichText[]
     checked: boolean
-    children?: BlockBase[]
+    children?: Block[]
   }
 }
 
@@ -115,7 +115,7 @@ export interface ToggleBlock extends BlockBase {
   type: "toggle"
   toggle: {
     text: RichText[]
-    children?: BlockBase[]
+    children?: Block[]
   }
 }
 


### PR DESCRIPTION
Block children are currently of type BlockBase[]. In my use case I am unable to fetch the children of a particular block and add them to this property because of its type.

Also added .github to prettierignore since it was breaking the checks. 