### PR TITLE
chore(ci): nodejs v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Given that nodejs v16 is the latest LTS, I think we could include it in CI tests.

https://nodejs.org/en/about/releases/