### PR TITLE
missing `await` in TypeScript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ the `APIErrorCode` enum are returned from the server. Codes in the
 
 ```ts
 try {
-  const response = notion.databases.query({
+  const response = await notion.databases.query({
     /* ... */
   })
 } catch (error: unknown) {


### PR DESCRIPTION
There's a missing `await` in the TypeScript example