### PR TITLE
Let id and color optional in SelectOption

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -338,8 +338,8 @@ export interface BotUser extends UserBase {
 
 export interface SelectOption {
   name: string
-  id: string
-  color: Color
+  id?: string
+  color?: Color
 }
 
 export type MultiSelectOption = SelectOption


### PR DESCRIPTION
fix #131 

Change id and color of interface SelectOption to be optional in src/api-types.ts.

```
export interface SelectOption {
  name: string
  id?: string
  color?: Color
}
```

This PR may be also related to #129.