### PR TITLE
Require one of name or id in SelectOption, make color optional

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -336,11 +336,19 @@ export interface BotUser extends UserBase {
  * Misc (output)
  */
 
-export interface SelectOption {
-  name: string
-  id: string
-  color: Color
+export interface SelectOptionBase {
+  color?: Color
 }
+
+export interface SelectOptionWithName extends SelectOptionBase {
+  name: string
+}
+
+export interface SelectOptionWithId extends SelectOptionBase {
+  id: string
+}
+
+type SelectOption = SelectOptionWithName | SelectOptionWithId
 
 export type MultiSelectOption = SelectOption
 

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -342,9 +342,11 @@ export interface SelectOptionBase {
 
 export interface SelectOptionWithName extends SelectOptionBase {
   name: string
+  id?: never
 }
 
 export interface SelectOptionWithId extends SelectOptionBase {
+  name?: never
   id: string
 }
 

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -348,7 +348,7 @@ export interface SelectOptionWithId extends SelectOptionBase {
   id: string
 }
 
-type SelectOption = SelectOptionWithName | SelectOptionWithId
+export type SelectOption = SelectOptionWithName | SelectOptionWithId
 
 export type MultiSelectOption = SelectOption
 


### PR DESCRIPTION
Changes `api-types.ts` to require one of `name` or `id` in `SelectOption` and make `color` optional.

Fixes #129 and #131.