### PR TITLE
Correct type from `file` to `files` in the typing file

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -154,7 +154,7 @@ export type Property =
   | MultiSelectProperty
   | DateProperty
   | PeopleProperty
-  | FileProperty
+  | FilesProperty
   | CheckboxProperty
   | URLProperty
   | EmailProperty
@@ -222,7 +222,7 @@ export interface PeopleProperty extends PropertyBase {
   people: Record<string, never>
 }
 
-export interface FileProperty extends PropertyBase {
+export interface FilesProperty extends PropertyBase {
   type: "files"
   file: Record<string, never>
 }

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -223,7 +223,7 @@ export interface PeopleProperty extends PropertyBase {
 }
 
 export interface FileProperty extends PropertyBase {
-  type: "file"
+  type: "files"
   file: Record<string, never>
 }
 


### PR DESCRIPTION
Returns from the API show that the type of a file property should be `files`, not `file`.

Also, this PR makes a name change to `FileProperty` so that it follows the naming convention.

It fixes #107.