### PR TITLE
Add show_original to rollup property types

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -284,6 +284,7 @@ export interface RollupProperty extends PropertyBase {
       | "min"
       | "max"
       | "range"
+      | "show_original"
   }
 }
 


### PR DESCRIPTION
Updating for [this fix](https://developers.notion.com/changelog/rollup-property-functions-now-include-show_original)