### PR TITLE
Add name to property schema object

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -170,6 +170,7 @@ export type Property =
 export interface PropertyBase {
   id: string
   type: string
+  name: string
 }
 
 export interface TitleProperty extends PropertyBase {


### PR DESCRIPTION
Adding name to property schema object for this [update](https://developers.notion.com/changelog/database-property-objects-now-include-property-name).