### PR TITLE
Add update and retrieve block endpoints to sdk

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -49,6 +49,12 @@ import {
   DatabasesCreateParameters,
   DatabasesCreateResponse,
   databasesCreate,
+  BlocksRetrieveParameters,
+  BlocksRetrieveResponse,
+  blocksRetrieve,
+  BlocksUpdateParameters,
+  BlocksUpdateResponse,
+  blocksUpdate,
 } from "./api-endpoints"
 import nodeFetch from "node-fetch"
 import {
@@ -190,6 +196,35 @@ export default class Client {
    */
 
   public readonly blocks = {
+    /**
+     * Retrieve block
+     */
+    retrieve: (
+      args: WithAuth<BlocksRetrieveParameters>
+    ): Promise<BlocksRetrieveResponse> => {
+      return this.request<BlocksRetrieveResponse>({
+        path: blocksRetrieve.path(args),
+        method: blocksRetrieve.method,
+        query: pick(args, blocksRetrieve.queryParams),
+        body: pick(args, blocksRetrieve.bodyParams),
+        auth: args?.auth,
+      })
+    },
+
+    /**
+     * Update block
+     */
+    update: (
+      args: WithAuth<BlocksUpdateParameters>
+    ): Promise<BlocksUpdateResponse> => {
+      return this.request<BlocksUpdateResponse>({
+        path: blocksUpdate.path(args),
+        method: blocksUpdate.method,
+        query: pick(args, blocksUpdate.queryParams),
+        body: pick(args, blocksUpdate.bodyParams),
+        auth: args?.auth,
+      })
+    },
     children: {
       /**
        * Append block children

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -26,12 +26,68 @@ import {
   ParentPageInput,
   PropertySchema,
   RichTextInput,
+  UpdateBlock,
 } from "./api-types"
 
 // TODO: type assertions to verify that each interface is synchronized to the list of keys in the runtime value below.
 
 // TODO: instead of importing interfaces like BlockBase, should i use a type alias to Block?
 // TODO: need an input version of Block
+
+/*
+ * blocks.retrieve()
+ */
+
+interface BlocksRetrievePathParameters {
+  block_id: string
+}
+interface BlocksRetrieveQueryParameters {}
+interface BlocksRetrieveBodyParameters {}
+
+export interface BlocksRetrieveParameters
+  extends BlocksRetrievePathParameters,
+    BlocksRetrieveQueryParameters,
+    BlocksRetrieveBodyParameters {}
+export interface BlocksRetrieveResponse extends BlockBase {}
+
+export const blocksRetrieve = {
+  method: "get",
+  pathParams: ["block_id"],
+  queryParams: [],
+  bodyParams: [],
+  path: (p: BlocksRetrievePathParameters) => `blocks/${p.block_id}`,
+} as const
+
+/*
+ * blocks.update()
+ */
+
+interface BlocksUpdatePathParameters {
+  block_id: string
+}
+interface BlocksUpdateQueryParameters {}
+type BlocksUpdateBodyParameters = UpdateBlock
+
+export type BlocksUpdateParameters = BlocksUpdatePathParameters &
+  BlocksUpdateQueryParameters &
+  BlocksUpdateBodyParameters
+export interface BlocksUpdateResponse extends BlockBase {}
+
+export const blocksUpdate = {
+  method: "patch",
+  pathParams: ["block_id"],
+  queryParams: [],
+  bodyParams: [
+    "paragraph",
+    "heading_1",
+    "heading_2",
+    "heading_3",
+    "bulleted_list_item",
+    "numbered_list_item",
+    "to_do",
+  ],
+  path: (p: BlocksUpdatePathParameters) => `blocks/${p.block_id}`,
+} as const
 
 /*
  * blocks.children.append()

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -84,6 +84,7 @@ export const blocksUpdate = {
     "heading_3",
     "bulleted_list_item",
     "numbered_list_item",
+    "toggle",
     "to_do",
   ],
   path: (p: BlocksUpdatePathParameters) => `blocks/${p.block_id}`,

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -569,6 +569,52 @@ export interface Page {
   url: string
 }
 
+/**
+ * Update Block (input)
+ */
+
+export type UpdateBlock =
+  | ParagraphUpdateBlock
+  | HeadingOneUpdateBlock
+  | HeadingTwoUpdateBlock
+  | HeadingThreeUpdateBlock
+  | BulletedListItemUpdateBlock
+  | NumberedListItemUpdateBlock
+  | ToDoUpdateBlock
+
+interface TextContentUpdate {
+  text: RichTextInput[]
+}
+
+interface ParagraphUpdateBlock {
+  paragraph: TextContentUpdate
+}
+
+interface HeadingOneUpdateBlock {
+  heading_1: TextContentUpdate
+}
+
+interface HeadingTwoUpdateBlock {
+  heading_2: TextContentUpdate
+}
+interface HeadingThreeUpdateBlock {
+  heading_3: TextContentUpdate
+}
+
+interface BulletedListItemUpdateBlock {
+  bulleted_list_item: TextContentUpdate
+}
+interface NumberedListItemUpdateBlock {
+  numbered_list_item: TextContentUpdate
+}
+
+interface ToDoUpdateBlock {
+  to_do: {
+    text?: RichTextInput[]
+    checked?: boolean
+  }
+}
+
 /*
  * Parent
  */

--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -580,6 +580,7 @@ export type UpdateBlock =
   | HeadingThreeUpdateBlock
   | BulletedListItemUpdateBlock
   | NumberedListItemUpdateBlock
+  | ToggleUpdateBlock
   | ToDoUpdateBlock
 
 interface TextContentUpdate {
@@ -606,6 +607,9 @@ interface BulletedListItemUpdateBlock {
 }
 interface NumberedListItemUpdateBlock {
   numbered_list_item: TextContentUpdate
+}
+interface ToggleUpdateBlock {
+  toggle: TextContentUpdate
 }
 
 interface ToDoUpdateBlock {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,7 +9,9 @@ export function assertNever(value: never): never {
   throw new Error(`Unexpected value should never occur: ${value}`)
 }
 
-export function pick<O extends unknown, K extends keyof O>(
+type AllKeys<T> = T extends unknown ? keyof T : never
+
+export function pick<O extends unknown, K extends AllKeys<O>>(
   base: O,
   keys: readonly K[]
 ): Pick<O, K> {


### PR DESCRIPTION
Adds support for
* PATCH /blocks/:id endpoint
* GET /blocks/:id endpoint
* update helper function to support Union types