### PR TITLE
feat: add RelationPropertyValue

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -656,6 +656,7 @@ export type PropertyValue =
   | DatePropertyValue
   | FormulaPropertyValue
   | RollupPropertyValue
+  | RelationPropertyValue
   | PeoplePropertyValue
   | FilesPropertyValue
   | CheckboxPropertyValue
@@ -768,6 +769,14 @@ export interface BooleanFormulaValue {
 export interface DateFormulaValue {
   type: "date"
   date: DatePropertyValue
+}
+
+export interface RelationPropertyValue extends PropertyValueBase {
+  type: "relation"
+  relation: RelationValue[]
+}
+export interface RelationValue {
+  id: string
 }
 
 export interface RollupPropertyValue extends PropertyValueBase {


### PR DESCRIPTION
Adds `RelationPropertyValue` to `PropertyValue`, as defined by [Relation Property value (developers.notion.com)](https://developers.notion.com/reference/page#relation-property-values) 

Fixes #165

Before: 
![image](https://user-images.githubusercontent.com/13189762/128099767-0f28e11f-a238-4b7d-9627-013e8fb1daea.png)
After:
![image](https://user-images.githubusercontent.com/13189762/128100127-33dd22a9-502d-4801-afc7-1fdca8b3a543.png)
