### PR TITLE
feat: correct typing for DateFormulaValue date field

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -467,6 +467,11 @@ export type BackgroundColor =
   | "pink_background"
   | "red_background"
 
+export interface Date {
+  start: string
+  end?: string
+}
+
 /*
  * Filter (input)
  */
@@ -794,10 +799,7 @@ export interface MultiSelectPropertyValue extends PropertyValueBase {
 
 export interface DatePropertyValue extends PropertyValueBase {
   type: "date"
-  date: {
-    start: string
-    end?: string
-  } | null
+  date: Date | null
 }
 
 export interface FormulaPropertyValue extends PropertyValueBase {
@@ -823,7 +825,7 @@ export interface BooleanFormulaValue {
 }
 export interface DateFormulaValue {
   type: "date"
-  date: DatePropertyValue
+  date: Date
 }
 
 export interface RollupPropertyValue extends PropertyValueBase {
@@ -837,7 +839,7 @@ export interface NumberRollupValue {
 }
 export interface DateRollupValue {
   type: "date"
-  date: DatePropertyValue | null
+  date: Date | null
 }
 export interface ArrayRollupValue {
   type: "array"


### PR DESCRIPTION
The response shape of a date formula returns as follows:
```json
"page": {
  "properties": {
    "Published Date": {
      "formula": {
        "date": {
          "start": ...
        }
      }
    }
  }
}
```

The current type for a date based formula, however, expects that there be a nested date field (i.e. `formula.date.date.start`). Thus, when using TypeScript, accessing the true path to the `start` field will produce a TS error:
```
Property 'start' does not exist on type 'DatePropertyValue'.ts(2339)
```