### PR TITLE
Fix pages.create() response type

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -261,7 +261,7 @@ export interface PagesCreateParameters
   extends PagesCreatePathParameters,
     PagesCreateQueryParameters,
     PagesCreateBodyParameters {}
-export interface PagesCreateResponse extends BlockBase {}
+export interface PagesCreateResponse extends Page {}
 
 export const pagesCreate = {
   method: "post",


### PR DESCRIPTION
Should return `Page` not `BlockBase`