### PR TITLE
Add missing bookmark block types

### DIFF
--- a/src/api-types.ts
+++ b/src/api-types.ts
@@ -55,6 +55,7 @@ export type Block =
   | ToggleBlock
   | ChildPageBlock
   | EmbedBlock
+  | BookmarkBlock
   | ImageBlock
   | VideoBlock
   | FileBlock
@@ -138,6 +139,14 @@ export interface ChildPageBlock extends BlockBase {
 export interface EmbedBlock extends BlockBase {
   type: "embed"
   embed: {
+    url: string
+    caption?: RichText[]
+  }
+}
+
+export interface BookmarkBlock extends BlockBase {
+  type: "bookmark"
+  bookmark: {
     url: string
     caption?: RichText[]
   }


### PR DESCRIPTION
Bookmark Blocks were documented on this [API Reference](https://developers.notion.com/reference/block#bookmark-blocks) page, but there are no type definitions of it.