### PR TITLE
Add helper script to check log in status before going through all publish checks

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,7 +11,8 @@
     "makenotion",
     "sendgrid",
     "blackmad",
-    "octokit"
+    "octokit",
+    "printf"
   ],
   // flagWords - list of words to be always considered incorrect
   // This is useful for offensive words and common spelling errors.

--- a/package.json
+++ b/package.json
@@ -22,14 +22,15 @@
   "main": "./build/src",
   "scripts": {
     "prepare": "npm run build",
-    "prepublishOnly": "npm run lint && npm run test",
+    "prepublishOnly": "npm run checkLoggedIn && npm run lint && npm run test",
     "build": "tsc",
     "prettier": "prettier --write .",
     "lint": "prettier --check . && eslint . --ext .ts && cspell '**/*' ",
     "test": "ava",
     "check-links": "git ls-files | grep md$ | xargs -n 1 markdown-link-check",
     "prebuild": "npm run clean",
-    "clean": "rm -rf ./build"
+    "clean": "rm -rf ./build",
+    "checkLoggedIn": "./scripts/verifyLoggedIn.sh"
   },
   "author": "",
   "license": "MIT",

--- a/scripts/verifyLoggedIn.sh
+++ b/scripts/verifyLoggedIn.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+##############################################################################
+#
+#		Verify the user is logged into NPM.
+#
+#		Useful when publishing to NPM.
+#
+##############################################################################
+
+npm whoami &> /dev/null
+if [[ $? -ne 0 ]]; then 
+  printf "❌ Failed: Please login to NPM before publishing.\n\n"; 
+  exit 1; 
+fi


### PR DESCRIPTION
**Description:** Currently when we publish a new version, if you aren't logged into NPM you don't see an error until after all the checks. This PR adds a new script that will check that you are logged in before running linter and tests. Sadly this won't verify you have the correct permissions on NPM but it's a start.