### PR TITLE
Fix notion.users.list arg in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Make a request to any Notion API endpoint.
 
 ```js
 ;(async () => {
-  const listUsersResponse = await notion.users.list()
+  const listUsersResponse = await notion.users.list({})
 })()
 ```
 


### PR DESCRIPTION
`notion.users.list()` is called without any arguments, but (the TypeScript typings, at least) indicate that it needs to take one argument, so this uses an empty object.