### PR TITLE
Added partials to QueryDatabaseResponse

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -52467,7 +52467,7 @@ export type QueryDatabaseResponse =
           }
       object: "list"
       results: Array<
-        | {
+        | { object: "page"; id: string } & Partial<{
             parent:
               | { type: "database_id"; database_id: IdRequest }
               | { type: "page_id"; page_id: IdRequest }
@@ -53742,14 +53742,11 @@ export type QueryDatabaseResponse =
               | null
               | { type: "file"; file: { url: string; expiry_time: string } }
               | null
-            object: "page"
-            id: string
             created_time: string
             last_edited_time: string
             archived: boolean
             url: string
-          }
-        | { object: "page"; id: string }
+          }>        
       >
       next_cursor: string | null
       has_more: boolean
@@ -53757,7 +53754,7 @@ export type QueryDatabaseResponse =
   | {
       object: "list"
       results: Array<
-        | {
+        | { object: "page"; id: string } & Partial<{
             parent:
               | { type: "database_id"; database_id: IdRequest }
               | { type: "page_id"; page_id: IdRequest }
@@ -55032,14 +55029,11 @@ export type QueryDatabaseResponse =
               | null
               | { type: "file"; file: { url: string; expiry_time: string } }
               | null
-            object: "page"
-            id: string
             created_time: string
             last_edited_time: string
             archived: boolean
             url: string
-          }
-        | { object: "page"; id: string }
+          }>
       >
       next_cursor: string | null
       has_more: boolean


### PR DESCRIPTION
This allows partial properties such as icon, archived & properties to be available without having to check for this property. This provides a fix for #247.  This also seems to be an issue that was offshot from #243 . This is why I've used partials to encapsulate the properties and co. This only aims to fix for the `QueryDatabaseResponse` type, but I believe there are other affected types. If this change was in the right direction, I could fix up the rest. 

Since this is a generated file, I'm not sure if this is the correct way. 
