### PR TITLE
Add issue body to list generated by github issues as blocks

### DIFF
--- a/examples/notion-github-sync/Dockerfile
+++ b/examples/notion-github-sync/Dockerfile
@@ -1,0 +1,6 @@
+FROM node
+WORKDIR /usr/app
+COPY package.json .
+RUN npm install --quiet
+COPY . .
+RUN ["node","index.js"]

--- a/examples/notion-github-sync/Dockerfile
+++ b/examples/notion-github-sync/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /usr/app
 COPY package.json .
 RUN npm install --quiet
 COPY . .
-RUN ["node","index.js"]
+ENTRYPOINT [ "node", "index.js" ]

--- a/examples/notion-github-sync/Dockerfile
+++ b/examples/notion-github-sync/Dockerfile
@@ -1,6 +1,10 @@
-FROM node
+FROM alpine/git as intermediate
 WORKDIR /usr/app
-COPY package.json .
+RUN git clone https://github.com/ralsuwaidi/notion-sdk-js.git
+
+
+FROM node
+COPY --from=intermediate /usr/app /usr/app
+WORKDIR /usr/app/notion-sdk-js/examples/notion-github-sync
 RUN npm install --quiet
-COPY . .
 ENTRYPOINT [ "node", "index.js" ]

--- a/examples/notion-github-sync/build.sh
+++ b/examples/notion-github-sync/build.sh
@@ -1,0 +1,1 @@
+docker build . -t notion-chq-integration

--- a/examples/notion-github-sync/index.js
+++ b/examples/notion-github-sync/index.js
@@ -11,6 +11,7 @@ const { Client } = require("@notionhq/client")
 const dotenv = require("dotenv")
 const { Octokit } = require("octokit")
 const _ = require("lodash")
+const { markdownToBlocks } = require("@tryfabric/martian")
 
 dotenv.config()
 const octokit = new Octokit({ auth: process.env.GITHUB_KEY })
@@ -24,6 +25,7 @@ const OPERATION_BATCH_SIZE = 10
  * { [issueId: string]: string }
  */
 const gitHubIssuesIdToNotionPageId = {}
+
 
 /**
  * Initialize local data store.
@@ -164,22 +166,8 @@ async function createPages(pagesToCreate) {
         notion.pages.create({
           parent: { database_id: databaseId },
           properties: getPropertiesFromIssue(issue),
-          children: [
-            {
-              object: 'block',
-              type: 'paragraph',
-              paragraph: {
-                text: [
-                  {
-                    type: 'text',
-                    text: {
-                      content: issue.body,
-                    },
-                  },
-                ],
-              },
-            },
-          ]
+          children: markdownToBlocks(issue.body),
+
         })
       )
     )

--- a/examples/notion-github-sync/index.js
+++ b/examples/notion-github-sync/index.js
@@ -1,6 +1,6 @@
 /* ================================================================================
 
-	notion-github-sync.
+  notion-github-sync.
   
   Glitch example: https://glitch.com/edit/#!/notion-github-sync
   Find the official Notion API client @ https://github.com/makenotion/notion-sdk-js/
@@ -115,6 +115,7 @@ async function getGitHubIssuesForRepository() {
           state: issue.state,
           comment_count: issue.comments,
           url: issue.html_url,
+          body: issue.body,
         })
       }
     }
@@ -163,6 +164,22 @@ async function createPages(pagesToCreate) {
         notion.pages.create({
           parent: { database_id: databaseId },
           properties: getPropertiesFromIssue(issue),
+          children: [
+            {
+              object: 'block',
+              type: 'paragraph',
+              paragraph: {
+                text: [
+                  {
+                    type: 'text',
+                    text: {
+                      content: issue.body,
+                    },
+                  },
+                ],
+              },
+            },
+          ]
         })
       )
     )

--- a/examples/notion-github-sync/index.js
+++ b/examples/notion-github-sync/index.js
@@ -208,6 +208,10 @@ async function updatePages(pagesToUpdate) {
  */
 function getPropertiesFromIssue(issue) {
   const { title, number, state, comment_count, url } = issue
+  const task_description = /(Task Description:).*/.exec(issue.body)
+  const skills_needed = /(Skills Needed:).*/.exec(issue.body)
+
+
   return {
     Name: {
       title: [{ type: "text", text: { content: title } }],
@@ -224,5 +228,11 @@ function getPropertiesFromIssue(issue) {
     "Issue URL": {
       url,
     },
+    "Task Description": {
+      rich_text: [{ text: { content: task_description == null ? '' : task_description[0].replace('Task Description:','') } }],
+    },
+    "Skills Needed": {
+      rich_text: [{ text: { content: skills_needed == null ? '' : skills_needed[0].replace('Skills Needed:','') } }],
+    }
   }
 }

--- a/examples/notion-github-sync/index.js
+++ b/examples/notion-github-sync/index.js
@@ -208,9 +208,12 @@ async function updatePages(pagesToUpdate) {
  */
 function getPropertiesFromIssue(issue) {
   const { title, number, state, comment_count, url } = issue
-  const task_description = /(Task Description:).*/.exec(issue.body)
-  const skills_needed = /(Skills Needed:).*/.exec(issue.body)
+  let task_description = /(Task Description:).*/.exec(issue.body)
+  let skills_needed = /(Skills Needed:).*/.exec(issue.body)
 
+  // Replace Task description and Skills Needed with rest of sentence
+  task_description = task_description == null ? '' : task_description[0].replace('Task Description:', '').trim()
+  skills_needed = skills_needed == null ? '' : skills_needed[0].replace('Skills Needed:', '').trim()
 
   return {
     Name: {
@@ -229,10 +232,10 @@ function getPropertiesFromIssue(issue) {
       url,
     },
     "Task Description": {
-      rich_text: [{ text: { content: task_description == null ? '' : task_description[0].replace('Task Description:','') } }],
+      rich_text: [{ text: { content: task_description } }],
     },
     "Skills Needed": {
-      rich_text: [{ text: { content: skills_needed == null ? '' : skills_needed[0].replace('Skills Needed:','') } }],
+      rich_text: [{ text: { content: skills_needed } }],
     }
   }
 }

--- a/examples/notion-github-sync/package.json
+++ b/examples/notion-github-sync/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@notionhq/client": "^0.4.2",
+    "@tryfabric/martian": "^1.1.1",
     "dotenv": "^10.0.0",
     "lodash": "^4.17.21",
     "octokit": "^1.1.0"

--- a/examples/notion-github-sync/run.sh
+++ b/examples/notion-github-sync/run.sh
@@ -1,0 +1,1 @@
+docker run --rm notion-chq-integration

--- a/examples/notion-github-sync/run.sh
+++ b/examples/notion-github-sync/run.sh
@@ -1,1 +1,1 @@
-docker run --rm notion-chq-integration
+docker run --rm -v ${PWD}/.env:/usr/app/notion-sdk-js/examples/notion-github-sync/.env notion-chq-integration


### PR DESCRIPTION
In addition to generating blocks per issue and filling the properties. The issue is now also filled with notion blocks that is converted from markdown from the github issue body