### PR TITLE
example didn't reflect new database query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ try {
   const myPage = await notion.databases.query({
     database_id: databaseId,
     filter: {
-      property: "Landmark",
-      text: {
-        contains: "Bridge",
-      },
+      and: [{
+        property: "Landmark",
+        text: {
+          contains: "Bridge",
+        },
+      }],
     },
   })
 } catch (error) {


### PR DESCRIPTION
With the new API, filter in database query should have a "or" or "and" (and maybe some other filter) in the first property of filter and it must be an array.