### PR TITLE
Export block types

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -4506,485 +4506,550 @@ type LanguageRequest =
   | "yaml"
   | "java/c/c++/c#"
 
-type BlockObjectResponse =
-  | {
-      type: "paragraph"
-      paragraph: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "heading_1"
-      heading_1: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "heading_2"
-      heading_2: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "heading_3"
-      heading_3: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "bulleted_list_item"
-      bulleted_list_item: {
-        rich_text: Array<RichTextItemResponse>
-        color: ApiColor
-      }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "numbered_list_item"
-      numbered_list_item: {
-        rich_text: Array<RichTextItemResponse>
-        color: ApiColor
-      }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "quote"
-      quote: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "to_do"
-      to_do: {
-        rich_text: Array<RichTextItemResponse>
-        color: ApiColor
-        checked: boolean
-      }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "toggle"
-      toggle: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "template"
-      template: { rich_text: Array<RichTextItemResponse> }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "synced_block"
-      synced_block: {
-        synced_from: { type: "block_id"; block_id: IdRequest } | null
-      }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "child_page"
-      child_page: { title: string }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "child_database"
-      child_database: { title: string }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "equation"
-      equation: { expression: string }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "code"
-      code: {
-        rich_text: Array<RichTextItemResponse>
+export type ParagraphBlock = {
+  type: "paragraph"
+  paragraph: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type Heading1Block = {
+  type: "heading_1"
+  heading_1: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type Heading2Block = {
+  type: "heading_2"
+  heading_2: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type Heading3Block = {
+  type: "heading_3"
+  heading_3: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type BulletedListItemBlock = {
+  type: "bulleted_list_item"
+  bulleted_list_item: {
+    rich_text: Array<RichTextItemResponse>
+    color: ApiColor
+  }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type NumberedListItemBlock = {
+  type: "numbered_list_item"
+  numbered_list_item: {
+    rich_text: Array<RichTextItemResponse>
+    color: ApiColor
+  }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type QuoteBlock = {
+  type: "quote"
+  quote: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type ToDoBlock = {
+  type: "to_do"
+  to_do: {
+    rich_text: Array<RichTextItemResponse>
+    color: ApiColor
+    checked: boolean
+  }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type ToggleBlock = {
+  type: "toggle"
+  toggle: { rich_text: Array<RichTextItemResponse>; color: ApiColor }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type TemplateBlock = {
+  type: "template"
+  template: { rich_text: Array<RichTextItemResponse> }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type SyncedBlockBlock = {
+  type: "synced_block"
+  synced_block: {
+    synced_from: { type: "block_id"; block_id: IdRequest } | null
+  }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type ChildPageBlock = {
+  type: "child_page"
+  child_page: { title: string }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type ChildDatabaseBlock = {
+  type: "child_database"
+  child_database: { title: string }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type EquationBlock = {
+  type: "equation"
+  equation: { expression: string }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type CodeBlock = {
+  type: "code"
+  code: {
+    rich_text: Array<RichTextItemResponse>
+    caption: Array<RichTextItemResponse>
+    language: LanguageRequest
+  }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type CalloutBlock = {
+  type: "callout"
+  callout: {
+    rich_text: Array<RichTextItemResponse>
+    color: ApiColor
+    icon:
+      | { type: "emoji"; emoji: EmojiRequest }
+      | null
+      | { type: "external"; external: { url: TextRequest } }
+      | null
+      | { type: "file"; file: { url: string; expiry_time: string } }
+      | null
+  }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type DividerBlock = {
+  type: "divider"
+  divider: EmptyObject
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type BreadcrumbBlock = {
+  type: "breadcrumb"
+  breadcrumb: EmptyObject
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type TableOfContentsBlock = {
+  type: "table_of_contents"
+  table_of_contents: { color: ApiColor }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type ColumnListBlock = {
+  type: "column_list"
+  column_list: EmptyObject
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type ColumnBlock = {
+  type: "column"
+  column: EmptyObject
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+export type LinkToPageBlock = {
+  type: "link_to_page"
+  link_to_page:
+    | { type: "page_id"; page_id: IdRequest }
+    | { type: "database_id"; database_id: IdRequest }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type TableBlock = {
+  type: "table"
+  table: {
+    has_column_header: boolean
+    has_row_header: boolean
+    table_width: number
+  }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type TableRowBlock = {
+  type: "table_row"
+  table_row: { cells: Array<Array<RichTextItemResponse>> }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type EmbedBlock = {
+  type: "embed"
+  embed: { url: string; caption: Array<RichTextItemResponse> }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type BookmarkBlock = {
+  type: "bookmark"
+  bookmark: { url: string; caption: Array<RichTextItemResponse> }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type ImageBlock = {
+  type: "image"
+  image:
+    | {
+        type: "external"
+        external: { url: TextRequest }
         caption: Array<RichTextItemResponse>
-        language: LanguageRequest
       }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "callout"
-      callout: {
-        rich_text: Array<RichTextItemResponse>
-        color: ApiColor
-        icon:
-          | { type: "emoji"; emoji: EmojiRequest }
-          | null
-          | { type: "external"; external: { url: TextRequest } }
-          | null
-          | { type: "file"; file: { url: string; expiry_time: string } }
-          | null
+    | {
+        type: "file"
+        file: { url: string; expiry_time: string }
+        caption: Array<RichTextItemResponse>
       }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "divider"
-      divider: EmptyObject
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "breadcrumb"
-      breadcrumb: EmptyObject
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "table_of_contents"
-      table_of_contents: { color: ApiColor }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "column_list"
-      column_list: EmptyObject
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "column"
-      column: EmptyObject
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "link_to_page"
-      link_to_page:
-        | { type: "page_id"; page_id: IdRequest }
-        | { type: "database_id"; database_id: IdRequest }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "table"
-      table: {
-        has_column_header: boolean
-        has_row_header: boolean
-        table_width: number
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type VideoBlock = {
+  type: "video"
+  video:
+    | {
+        type: "external"
+        external: { url: TextRequest }
+        caption: Array<RichTextItemResponse>
       }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "table_row"
-      table_row: { cells: Array<Array<RichTextItemResponse>> }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "embed"
-      embed: { url: string; caption: Array<RichTextItemResponse> }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "bookmark"
-      bookmark: { url: string; caption: Array<RichTextItemResponse> }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "image"
-      image:
-        | {
-            type: "external"
-            external: { url: TextRequest }
-            caption: Array<RichTextItemResponse>
-          }
-        | {
-            type: "file"
-            file: { url: string; expiry_time: string }
-            caption: Array<RichTextItemResponse>
-          }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "video"
-      video:
-        | {
-            type: "external"
-            external: { url: TextRequest }
-            caption: Array<RichTextItemResponse>
-          }
-        | {
-            type: "file"
-            file: { url: string; expiry_time: string }
-            caption: Array<RichTextItemResponse>
-          }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "pdf"
-      pdf:
-        | {
-            type: "external"
-            external: { url: TextRequest }
-            caption: Array<RichTextItemResponse>
-          }
-        | {
-            type: "file"
-            file: { url: string; expiry_time: string }
-            caption: Array<RichTextItemResponse>
-          }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "file"
-      file:
-        | {
-            type: "external"
-            external: { url: TextRequest }
-            caption: Array<RichTextItemResponse>
-          }
-        | {
-            type: "file"
-            file: { url: string; expiry_time: string }
-            caption: Array<RichTextItemResponse>
-          }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "audio"
-      audio:
-        | {
-            type: "external"
-            external: { url: TextRequest }
-            caption: Array<RichTextItemResponse>
-          }
-        | {
-            type: "file"
-            file: { url: string; expiry_time: string }
-            caption: Array<RichTextItemResponse>
-          }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "link_preview"
-      link_preview: { url: TextRequest }
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
-  | {
-      type: "unsupported"
-      unsupported: EmptyObject
-      object: "block"
-      id: string
-      created_time: string
-      created_by: { id: IdRequest; object: "user" }
-      last_edited_time: string
-      last_edited_by: { id: IdRequest; object: "user" }
-      has_children: boolean
-      archived: boolean
-    }
+    | {
+        type: "file"
+        file: { url: string; expiry_time: string }
+        caption: Array<RichTextItemResponse>
+      }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type PdfBlock = {
+  type: "pdf"
+  pdf:
+    | {
+        type: "external"
+        external: { url: TextRequest }
+        caption: Array<RichTextItemResponse>
+      }
+    | {
+        type: "file"
+        file: { url: string; expiry_time: string }
+        caption: Array<RichTextItemResponse>
+      }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type FileBlock = {
+  type: "file"
+  file:
+    | {
+        type: "external"
+        external: { url: TextRequest }
+        caption: Array<RichTextItemResponse>
+      }
+    | {
+        type: "file"
+        file: { url: string; expiry_time: string }
+        caption: Array<RichTextItemResponse>
+      }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type AudioBlock = {
+  type: "audio"
+  audio:
+    | {
+        type: "external"
+        external: { url: TextRequest }
+        caption: Array<RichTextItemResponse>
+      }
+    | {
+        type: "file"
+        file: { url: string; expiry_time: string }
+        caption: Array<RichTextItemResponse>
+      }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type LinkPreviewBlock = {
+  type: "link_preview"
+  link_preview: { url: TextRequest }
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type UnsupportedBlock = {
+  type: "unsupported"
+  unsupported: EmptyObject
+  object: "block"
+  id: string
+  created_time: string
+  created_by: { id: IdRequest; object: "user" }
+  last_edited_time: string
+  last_edited_by: { id: IdRequest; object: "user" }
+  has_children: boolean
+  archived: boolean
+}
+
+export type BlockObjectResponse =
+  | ParagraphBlock
+  | Heading1Block
+  | Heading2Block
+  | Heading3Block
+  | BulletedListItemBlock
+  | NumberedListItemBlock
+  | QuoteBlock
+  | ToDoBlock
+  | ToggleBlock
+  | TemplateBlock
+  | SyncedBlockBlock
+  | ChildPageBlock
+  | ChildDatabaseBlock
+  | EquationBlock
+  | CodeBlock
+  | CalloutBlock
+  | DividerBlock
+  | BreadcrumbBlock
+  | TableOfContentsBlock
+  | ColumnListBlock
+  | ColumnBlock
+  | LinkToPageBlock
+  | TableBlock
+  | TableRowBlock
+  | EmbedBlock
+  | BookmarkBlock
+  | ImageBlock
+  | VideoBlock
+  | PdfBlock
+  | FileBlock
+  | AudioBlock
+  | LinkPreviewBlock
+  | UnsupportedBlock
 
 type DateRequest = {
   start: string


### PR DESCRIPTION
Related with https://github.com/makenotion/notion-sdk-js/issues/280

Create block specific types and export them.
They were generated base on `BlockObjectResponse`.
No extra param or type was added.

- ParagraphBlock
- Heading1Block
- Heading2Block
- Heading3Block
- BulletedListItemBlock
- NumberedListItemBlock
- QuoteBlock
- ToDoBlock
- ToggleBlock
- TemplateBlock
- SyncedBlockBlock
- ChildPageBlock
- ChildDatabaseBlock
- EquationBlock
- CodeBlock
- CalloutBlock
- DividerBlock
- BreadcrumbBlock
- TableOfContentsBlock
- ColumnListBlock
- ColumnBlock
- LinkToPageBlock
- TableBlock
- TableRowBlock
- EmbedBlock
- BookmarkBlock
- ImageBlock
- VideoBlock
- PdfBlock
- FileBlock
- AudioBlock
- LinkPreviewBlock
- UnsupportedBlock
