### PR TITLE
Add `is-inline` property to create, update and retrieve database

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -10203,6 +10203,7 @@ export type GetDatabaseResponse =
       last_edited_time: string
       archived: boolean
       url: string
+      is_inline: boolean
     }
 
 export const getDatabase = {
@@ -10323,6 +10324,7 @@ type UpdateDatabaseBodyParameters = {
     | null
   >
   archived?: boolean
+  is_inline?: boolean
 }
 
 export type UpdateDatabaseParameters = UpdateDatabasePathParameters &
@@ -10566,13 +10568,14 @@ export type UpdateDatabaseResponse =
       last_edited_time: string
       archived: boolean
       url: string
+      is_inline: boolean
     }
 
 export const updateDatabase = {
   method: "patch",
   pathParams: ["database_id"],
   queryParams: [],
-  bodyParams: ["title", "icon", "cover", "properties", "archived"],
+  bodyParams: ["title", "icon", "cover", "properties", "archived", "is_inline"],
   path: (p: UpdateDatabasePathParameters): string =>
     `databases/${p.database_id}`,
 } as const
@@ -11109,6 +11112,7 @@ type CreateDatabaseBodyParameters = {
     | null
   cover?: { external: { url: TextRequest }; type?: "external" } | null
   title?: Array<RichTextItemRequest>
+  is_inline?: boolean
 }
 
 export type CreateDatabaseParameters = CreateDatabaseBodyParameters
@@ -11351,13 +11355,14 @@ export type CreateDatabaseResponse =
       last_edited_time: string
       archived: boolean
       url: string
+      is_inline: boolean
     }
 
 export const createDatabase = {
   method: "post",
   pathParams: [],
   queryParams: [],
-  bodyParams: ["parent", "properties", "icon", "cover", "title"],
+  bodyParams: ["parent", "properties", "icon", "cover", "title", "is_inline"],
   path: (): string => `databases`,
 } as const
 


### PR DESCRIPTION
I find `is_inline` property in [API reference](https://developers.notion.com/reference/database#all-databases:~:text=false-,is_inline,-boolean). Then I send a request to test it and found that it did create a database for inline.

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/36906329/176572881-8f1be657-753e-4b3b-bfff-2acaecd3cdd2.png">

Just as I was doing notion API integration recently, I need this feature, so I sent this PR.



Create inline database example:
```bash
curl --location --request POST 'https://api.notion.com/v1/databases/' \
--header 'Content-Type: application/json' \
--header 'Notion-Version: 2022-02-22' \
--header 'Authorization: {token}' \
--data-raw '{
    "parent": {
        "type": "page_id",
        "page_id": "{page_id}"
    },
    "title": [
        {
            "type": "text",
            "text": {
                "content": "Grocery List"
            }
        }
    ],
    "properties": {
        "Name": {
            "title": {}
        },
        "Date": {
            "date": {}
        }
    },
    "is_inline": true
}'
```
Please replace `{token}` and `{page_id}` with your own generated.