### PR TITLE
update search to use arrow function

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -507,7 +507,9 @@ export default class Client {
   /**
    * Search
    */
-  public search(args: WithAuth<SearchParameters>): Promise<SearchResponse> {
+  public search = (
+    args: WithAuth<SearchParameters>
+  ): Promise<SearchResponse> => {
     return this.request<SearchResponse>({
       path: search.path(),
       method: search.method,


### PR DESCRIPTION
Closes https://github.com/makenotion/notion-sdk-js/issues/329

Previous TypeError:
```
TypeError: Cannot read properties of undefined (reading 'request')
    at search (/path/to/node_modules/@notionhq/client/src/Client.ts:511:17)
    at iteratePaginatedAPI (/path/to/node_modules/@notionhq/client/src/helpers.ts:50:49)
    at iteratePaginatedAPI.next (<anonymous>)
    at example.example (/path/to/example.ts)
```

Passing in the `listFn` as `client.search` meant that `this.request({...})` is unavailable unless `search` is an arrow function.