### PR TITLE
Support status property, toggle headers, and page property values

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -47,6 +47,751 @@ export type UserObjectResponse =
   | PersonUserObjectResponse
   | BotUserObjectResponse
 
+type StringRequest = string
+
+type SelectColor =
+  | "default"
+  | "gray"
+  | "brown"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "purple"
+  | "pink"
+  | "red"
+
+type SelectPropertyResponse = {
+  id: StringRequest
+  name: StringRequest
+  color: SelectColor
+}
+
+type TimeZoneRequest =
+  | "Africa/Abidjan"
+  | "Africa/Accra"
+  | "Africa/Addis_Ababa"
+  | "Africa/Algiers"
+  | "Africa/Asmara"
+  | "Africa/Asmera"
+  | "Africa/Bamako"
+  | "Africa/Bangui"
+  | "Africa/Banjul"
+  | "Africa/Bissau"
+  | "Africa/Blantyre"
+  | "Africa/Brazzaville"
+  | "Africa/Bujumbura"
+  | "Africa/Cairo"
+  | "Africa/Casablanca"
+  | "Africa/Ceuta"
+  | "Africa/Conakry"
+  | "Africa/Dakar"
+  | "Africa/Dar_es_Salaam"
+  | "Africa/Djibouti"
+  | "Africa/Douala"
+  | "Africa/El_Aaiun"
+  | "Africa/Freetown"
+  | "Africa/Gaborone"
+  | "Africa/Harare"
+  | "Africa/Johannesburg"
+  | "Africa/Juba"
+  | "Africa/Kampala"
+  | "Africa/Khartoum"
+  | "Africa/Kigali"
+  | "Africa/Kinshasa"
+  | "Africa/Lagos"
+  | "Africa/Libreville"
+  | "Africa/Lome"
+  | "Africa/Luanda"
+  | "Africa/Lubumbashi"
+  | "Africa/Lusaka"
+  | "Africa/Malabo"
+  | "Africa/Maputo"
+  | "Africa/Maseru"
+  | "Africa/Mbabane"
+  | "Africa/Mogadishu"
+  | "Africa/Monrovia"
+  | "Africa/Nairobi"
+  | "Africa/Ndjamena"
+  | "Africa/Niamey"
+  | "Africa/Nouakchott"
+  | "Africa/Ouagadougou"
+  | "Africa/Porto-Novo"
+  | "Africa/Sao_Tome"
+  | "Africa/Timbuktu"
+  | "Africa/Tripoli"
+  | "Africa/Tunis"
+  | "Africa/Windhoek"
+  | "America/Adak"
+  | "America/Anchorage"
+  | "America/Anguilla"
+  | "America/Antigua"
+  | "America/Araguaina"
+  | "America/Argentina/Buenos_Aires"
+  | "America/Argentina/Catamarca"
+  | "America/Argentina/ComodRivadavia"
+  | "America/Argentina/Cordoba"
+  | "America/Argentina/Jujuy"
+  | "America/Argentina/La_Rioja"
+  | "America/Argentina/Mendoza"
+  | "America/Argentina/Rio_Gallegos"
+  | "America/Argentina/Salta"
+  | "America/Argentina/San_Juan"
+  | "America/Argentina/San_Luis"
+  | "America/Argentina/Tucuman"
+  | "America/Argentina/Ushuaia"
+  | "America/Aruba"
+  | "America/Asuncion"
+  | "America/Atikokan"
+  | "America/Atka"
+  | "America/Bahia"
+  | "America/Bahia_Banderas"
+  | "America/Barbados"
+  | "America/Belem"
+  | "America/Belize"
+  | "America/Blanc-Sablon"
+  | "America/Boa_Vista"
+  | "America/Bogota"
+  | "America/Boise"
+  | "America/Buenos_Aires"
+  | "America/Cambridge_Bay"
+  | "America/Campo_Grande"
+  | "America/Cancun"
+  | "America/Caracas"
+  | "America/Catamarca"
+  | "America/Cayenne"
+  | "America/Cayman"
+  | "America/Chicago"
+  | "America/Chihuahua"
+  | "America/Coral_Harbour"
+  | "America/Cordoba"
+  | "America/Costa_Rica"
+  | "America/Creston"
+  | "America/Cuiaba"
+  | "America/Curacao"
+  | "America/Danmarkshavn"
+  | "America/Dawson"
+  | "America/Dawson_Creek"
+  | "America/Denver"
+  | "America/Detroit"
+  | "America/Dominica"
+  | "America/Edmonton"
+  | "America/Eirunepe"
+  | "America/El_Salvador"
+  | "America/Ensenada"
+  | "America/Fort_Nelson"
+  | "America/Fort_Wayne"
+  | "America/Fortaleza"
+  | "America/Glace_Bay"
+  | "America/Godthab"
+  | "America/Goose_Bay"
+  | "America/Grand_Turk"
+  | "America/Grenada"
+  | "America/Guadeloupe"
+  | "America/Guatemala"
+  | "America/Guayaquil"
+  | "America/Guyana"
+  | "America/Halifax"
+  | "America/Havana"
+  | "America/Hermosillo"
+  | "America/Indiana/Indianapolis"
+  | "America/Indiana/Knox"
+  | "America/Indiana/Marengo"
+  | "America/Indiana/Petersburg"
+  | "America/Indiana/Tell_City"
+  | "America/Indiana/Vevay"
+  | "America/Indiana/Vincennes"
+  | "America/Indiana/Winamac"
+  | "America/Indianapolis"
+  | "America/Inuvik"
+  | "America/Iqaluit"
+  | "America/Jamaica"
+  | "America/Jujuy"
+  | "America/Juneau"
+  | "America/Kentucky/Louisville"
+  | "America/Kentucky/Monticello"
+  | "America/Knox_IN"
+  | "America/Kralendijk"
+  | "America/La_Paz"
+  | "America/Lima"
+  | "America/Los_Angeles"
+  | "America/Louisville"
+  | "America/Lower_Princes"
+  | "America/Maceio"
+  | "America/Managua"
+  | "America/Manaus"
+  | "America/Marigot"
+  | "America/Martinique"
+  | "America/Matamoros"
+  | "America/Mazatlan"
+  | "America/Mendoza"
+  | "America/Menominee"
+  | "America/Merida"
+  | "America/Metlakatla"
+  | "America/Mexico_City"
+  | "America/Miquelon"
+  | "America/Moncton"
+  | "America/Monterrey"
+  | "America/Montevideo"
+  | "America/Montreal"
+  | "America/Montserrat"
+  | "America/Nassau"
+  | "America/New_York"
+  | "America/Nipigon"
+  | "America/Nome"
+  | "America/Noronha"
+  | "America/North_Dakota/Beulah"
+  | "America/North_Dakota/Center"
+  | "America/North_Dakota/New_Salem"
+  | "America/Ojinaga"
+  | "America/Panama"
+  | "America/Pangnirtung"
+  | "America/Paramaribo"
+  | "America/Phoenix"
+  | "America/Port-au-Prince"
+  | "America/Port_of_Spain"
+  | "America/Porto_Acre"
+  | "America/Porto_Velho"
+  | "America/Puerto_Rico"
+  | "America/Punta_Arenas"
+  | "America/Rainy_River"
+  | "America/Rankin_Inlet"
+  | "America/Recife"
+  | "America/Regina"
+  | "America/Resolute"
+  | "America/Rio_Branco"
+  | "America/Rosario"
+  | "America/Santa_Isabel"
+  | "America/Santarem"
+  | "America/Santiago"
+  | "America/Santo_Domingo"
+  | "America/Sao_Paulo"
+  | "America/Scoresbysund"
+  | "America/Shiprock"
+  | "America/Sitka"
+  | "America/St_Barthelemy"
+  | "America/St_Johns"
+  | "America/St_Kitts"
+  | "America/St_Lucia"
+  | "America/St_Thomas"
+  | "America/St_Vincent"
+  | "America/Swift_Current"
+  | "America/Tegucigalpa"
+  | "America/Thule"
+  | "America/Thunder_Bay"
+  | "America/Tijuana"
+  | "America/Toronto"
+  | "America/Tortola"
+  | "America/Vancouver"
+  | "America/Virgin"
+  | "America/Whitehorse"
+  | "America/Winnipeg"
+  | "America/Yakutat"
+  | "America/Yellowknife"
+  | "Antarctica/Casey"
+  | "Antarctica/Davis"
+  | "Antarctica/DumontDUrville"
+  | "Antarctica/Macquarie"
+  | "Antarctica/Mawson"
+  | "Antarctica/McMurdo"
+  | "Antarctica/Palmer"
+  | "Antarctica/Rothera"
+  | "Antarctica/South_Pole"
+  | "Antarctica/Syowa"
+  | "Antarctica/Troll"
+  | "Antarctica/Vostok"
+  | "Arctic/Longyearbyen"
+  | "Asia/Aden"
+  | "Asia/Almaty"
+  | "Asia/Amman"
+  | "Asia/Anadyr"
+  | "Asia/Aqtau"
+  | "Asia/Aqtobe"
+  | "Asia/Ashgabat"
+  | "Asia/Ashkhabad"
+  | "Asia/Atyrau"
+  | "Asia/Baghdad"
+  | "Asia/Bahrain"
+  | "Asia/Baku"
+  | "Asia/Bangkok"
+  | "Asia/Barnaul"
+  | "Asia/Beirut"
+  | "Asia/Bishkek"
+  | "Asia/Brunei"
+  | "Asia/Calcutta"
+  | "Asia/Chita"
+  | "Asia/Choibalsan"
+  | "Asia/Chongqing"
+  | "Asia/Chungking"
+  | "Asia/Colombo"
+  | "Asia/Dacca"
+  | "Asia/Damascus"
+  | "Asia/Dhaka"
+  | "Asia/Dili"
+  | "Asia/Dubai"
+  | "Asia/Dushanbe"
+  | "Asia/Famagusta"
+  | "Asia/Gaza"
+  | "Asia/Harbin"
+  | "Asia/Hebron"
+  | "Asia/Ho_Chi_Minh"
+  | "Asia/Hong_Kong"
+  | "Asia/Hovd"
+  | "Asia/Irkutsk"
+  | "Asia/Istanbul"
+  | "Asia/Jakarta"
+  | "Asia/Jayapura"
+  | "Asia/Jerusalem"
+  | "Asia/Kabul"
+  | "Asia/Kamchatka"
+  | "Asia/Karachi"
+  | "Asia/Kashgar"
+  | "Asia/Kathmandu"
+  | "Asia/Katmandu"
+  | "Asia/Khandyga"
+  | "Asia/Kolkata"
+  | "Asia/Krasnoyarsk"
+  | "Asia/Kuala_Lumpur"
+  | "Asia/Kuching"
+  | "Asia/Kuwait"
+  | "Asia/Macao"
+  | "Asia/Macau"
+  | "Asia/Magadan"
+  | "Asia/Makassar"
+  | "Asia/Manila"
+  | "Asia/Muscat"
+  | "Asia/Nicosia"
+  | "Asia/Novokuznetsk"
+  | "Asia/Novosibirsk"
+  | "Asia/Omsk"
+  | "Asia/Oral"
+  | "Asia/Phnom_Penh"
+  | "Asia/Pontianak"
+  | "Asia/Pyongyang"
+  | "Asia/Qatar"
+  | "Asia/Qostanay"
+  | "Asia/Qyzylorda"
+  | "Asia/Rangoon"
+  | "Asia/Riyadh"
+  | "Asia/Saigon"
+  | "Asia/Sakhalin"
+  | "Asia/Samarkand"
+  | "Asia/Seoul"
+  | "Asia/Shanghai"
+  | "Asia/Singapore"
+  | "Asia/Srednekolymsk"
+  | "Asia/Taipei"
+  | "Asia/Tashkent"
+  | "Asia/Tbilisi"
+  | "Asia/Tehran"
+  | "Asia/Tel_Aviv"
+  | "Asia/Thimbu"
+  | "Asia/Thimphu"
+  | "Asia/Tokyo"
+  | "Asia/Tomsk"
+  | "Asia/Ujung_Pandang"
+  | "Asia/Ulaanbaatar"
+  | "Asia/Ulan_Bator"
+  | "Asia/Urumqi"
+  | "Asia/Ust-Nera"
+  | "Asia/Vientiane"
+  | "Asia/Vladivostok"
+  | "Asia/Yakutsk"
+  | "Asia/Yangon"
+  | "Asia/Yekaterinburg"
+  | "Asia/Yerevan"
+  | "Atlantic/Azores"
+  | "Atlantic/Bermuda"
+  | "Atlantic/Canary"
+  | "Atlantic/Cape_Verde"
+  | "Atlantic/Faeroe"
+  | "Atlantic/Faroe"
+  | "Atlantic/Jan_Mayen"
+  | "Atlantic/Madeira"
+  | "Atlantic/Reykjavik"
+  | "Atlantic/South_Georgia"
+  | "Atlantic/St_Helena"
+  | "Atlantic/Stanley"
+  | "Australia/ACT"
+  | "Australia/Adelaide"
+  | "Australia/Brisbane"
+  | "Australia/Broken_Hill"
+  | "Australia/Canberra"
+  | "Australia/Currie"
+  | "Australia/Darwin"
+  | "Australia/Eucla"
+  | "Australia/Hobart"
+  | "Australia/LHI"
+  | "Australia/Lindeman"
+  | "Australia/Lord_Howe"
+  | "Australia/Melbourne"
+  | "Australia/NSW"
+  | "Australia/North"
+  | "Australia/Perth"
+  | "Australia/Queensland"
+  | "Australia/South"
+  | "Australia/Sydney"
+  | "Australia/Tasmania"
+  | "Australia/Victoria"
+  | "Australia/West"
+  | "Australia/Yancowinna"
+  | "Brazil/Acre"
+  | "Brazil/DeNoronha"
+  | "Brazil/East"
+  | "Brazil/West"
+  | "CET"
+  | "CST6CDT"
+  | "Canada/Atlantic"
+  | "Canada/Central"
+  | "Canada/Eastern"
+  | "Canada/Mountain"
+  | "Canada/Newfoundland"
+  | "Canada/Pacific"
+  | "Canada/Saskatchewan"
+  | "Canada/Yukon"
+  | "Chile/Continental"
+  | "Chile/EasterIsland"
+  | "Cuba"
+  | "EET"
+  | "EST"
+  | "EST5EDT"
+  | "Egypt"
+  | "Eire"
+  | "Etc/GMT"
+  | "Etc/GMT+0"
+  | "Etc/GMT+1"
+  | "Etc/GMT+10"
+  | "Etc/GMT+11"
+  | "Etc/GMT+12"
+  | "Etc/GMT+2"
+  | "Etc/GMT+3"
+  | "Etc/GMT+4"
+  | "Etc/GMT+5"
+  | "Etc/GMT+6"
+  | "Etc/GMT+7"
+  | "Etc/GMT+8"
+  | "Etc/GMT+9"
+  | "Etc/GMT-0"
+  | "Etc/GMT-1"
+  | "Etc/GMT-10"
+  | "Etc/GMT-11"
+  | "Etc/GMT-12"
+  | "Etc/GMT-13"
+  | "Etc/GMT-14"
+  | "Etc/GMT-2"
+  | "Etc/GMT-3"
+  | "Etc/GMT-4"
+  | "Etc/GMT-5"
+  | "Etc/GMT-6"
+  | "Etc/GMT-7"
+  | "Etc/GMT-8"
+  | "Etc/GMT-9"
+  | "Etc/GMT0"
+  | "Etc/Greenwich"
+  | "Etc/UCT"
+  | "Etc/UTC"
+  | "Etc/Universal"
+  | "Etc/Zulu"
+  | "Europe/Amsterdam"
+  | "Europe/Andorra"
+  | "Europe/Astrakhan"
+  | "Europe/Athens"
+  | "Europe/Belfast"
+  | "Europe/Belgrade"
+  | "Europe/Berlin"
+  | "Europe/Bratislava"
+  | "Europe/Brussels"
+  | "Europe/Bucharest"
+  | "Europe/Budapest"
+  | "Europe/Busingen"
+  | "Europe/Chisinau"
+  | "Europe/Copenhagen"
+  | "Europe/Dublin"
+  | "Europe/Gibraltar"
+  | "Europe/Guernsey"
+  | "Europe/Helsinki"
+  | "Europe/Isle_of_Man"
+  | "Europe/Istanbul"
+  | "Europe/Jersey"
+  | "Europe/Kaliningrad"
+  | "Europe/Kiev"
+  | "Europe/Kirov"
+  | "Europe/Lisbon"
+  | "Europe/Ljubljana"
+  | "Europe/London"
+  | "Europe/Luxembourg"
+  | "Europe/Madrid"
+  | "Europe/Malta"
+  | "Europe/Mariehamn"
+  | "Europe/Minsk"
+  | "Europe/Monaco"
+  | "Europe/Moscow"
+  | "Europe/Nicosia"
+  | "Europe/Oslo"
+  | "Europe/Paris"
+  | "Europe/Podgorica"
+  | "Europe/Prague"
+  | "Europe/Riga"
+  | "Europe/Rome"
+  | "Europe/Samara"
+  | "Europe/San_Marino"
+  | "Europe/Sarajevo"
+  | "Europe/Saratov"
+  | "Europe/Simferopol"
+  | "Europe/Skopje"
+  | "Europe/Sofia"
+  | "Europe/Stockholm"
+  | "Europe/Tallinn"
+  | "Europe/Tirane"
+  | "Europe/Tiraspol"
+  | "Europe/Ulyanovsk"
+  | "Europe/Uzhgorod"
+  | "Europe/Vaduz"
+  | "Europe/Vatican"
+  | "Europe/Vienna"
+  | "Europe/Vilnius"
+  | "Europe/Volgograd"
+  | "Europe/Warsaw"
+  | "Europe/Zagreb"
+  | "Europe/Zaporozhye"
+  | "Europe/Zurich"
+  | "GB"
+  | "GB-Eire"
+  | "GMT"
+  | "GMT+0"
+  | "GMT-0"
+  | "GMT0"
+  | "Greenwich"
+  | "HST"
+  | "Hongkong"
+  | "Iceland"
+  | "Indian/Antananarivo"
+  | "Indian/Chagos"
+  | "Indian/Christmas"
+  | "Indian/Cocos"
+  | "Indian/Comoro"
+  | "Indian/Kerguelen"
+  | "Indian/Mahe"
+  | "Indian/Maldives"
+  | "Indian/Mauritius"
+  | "Indian/Mayotte"
+  | "Indian/Reunion"
+  | "Iran"
+  | "Israel"
+  | "Jamaica"
+  | "Japan"
+  | "Kwajalein"
+  | "Libya"
+  | "MET"
+  | "MST"
+  | "MST7MDT"
+  | "Mexico/BajaNorte"
+  | "Mexico/BajaSur"
+  | "Mexico/General"
+  | "NZ"
+  | "NZ-CHAT"
+  | "Navajo"
+  | "PRC"
+  | "PST8PDT"
+  | "Pacific/Apia"
+  | "Pacific/Auckland"
+  | "Pacific/Bougainville"
+  | "Pacific/Chatham"
+  | "Pacific/Chuuk"
+  | "Pacific/Easter"
+  | "Pacific/Efate"
+  | "Pacific/Enderbury"
+  | "Pacific/Fakaofo"
+  | "Pacific/Fiji"
+  | "Pacific/Funafuti"
+  | "Pacific/Galapagos"
+  | "Pacific/Gambier"
+  | "Pacific/Guadalcanal"
+  | "Pacific/Guam"
+  | "Pacific/Honolulu"
+  | "Pacific/Johnston"
+  | "Pacific/Kiritimati"
+  | "Pacific/Kosrae"
+  | "Pacific/Kwajalein"
+  | "Pacific/Majuro"
+  | "Pacific/Marquesas"
+  | "Pacific/Midway"
+  | "Pacific/Nauru"
+  | "Pacific/Niue"
+  | "Pacific/Norfolk"
+  | "Pacific/Noumea"
+  | "Pacific/Pago_Pago"
+  | "Pacific/Palau"
+  | "Pacific/Pitcairn"
+  | "Pacific/Pohnpei"
+  | "Pacific/Ponape"
+  | "Pacific/Port_Moresby"
+  | "Pacific/Rarotonga"
+  | "Pacific/Saipan"
+  | "Pacific/Samoa"
+  | "Pacific/Tahiti"
+  | "Pacific/Tarawa"
+  | "Pacific/Tongatapu"
+  | "Pacific/Truk"
+  | "Pacific/Wake"
+  | "Pacific/Wallis"
+  | "Pacific/Yap"
+  | "Poland"
+  | "Portugal"
+  | "ROC"
+  | "ROK"
+  | "Singapore"
+  | "Turkey"
+  | "UCT"
+  | "US/Alaska"
+  | "US/Aleutian"
+  | "US/Arizona"
+  | "US/Central"
+  | "US/East-Indiana"
+  | "US/Eastern"
+  | "US/Hawaii"
+  | "US/Indiana-Starke"
+  | "US/Michigan"
+  | "US/Mountain"
+  | "US/Pacific"
+  | "US/Pacific-New"
+  | "US/Samoa"
+  | "UTC"
+  | "Universal"
+  | "W-SU"
+  | "WET"
+  | "Zulu"
+
+type DateResponse = {
+  start: string
+  end: string | null
+  time_zone: TimeZoneRequest | null
+}
+
+type TextRequest = string
+
+type StringFormulaPropertyResponse = { type: "string"; string: string | null }
+
+type DateFormulaPropertyResponse = { type: "date"; date: DateResponse | null }
+
+type NumberFormulaPropertyResponse = { type: "number"; number: number | null }
+
+type BooleanFormulaPropertyResponse = {
+  type: "boolean"
+  boolean: boolean | null
+}
+
+type FormulaPropertyResponse =
+  | StringFormulaPropertyResponse
+  | DateFormulaPropertyResponse
+  | NumberFormulaPropertyResponse
+  | BooleanFormulaPropertyResponse
+
+type AnnotationResponse = {
+  bold: boolean
+  italic: boolean
+  strikethrough: boolean
+  underline: boolean
+  code: boolean
+  color:
+    | "default"
+    | "gray"
+    | "brown"
+    | "orange"
+    | "yellow"
+    | "green"
+    | "blue"
+    | "purple"
+    | "pink"
+    | "red"
+    | "gray_background"
+    | "brown_background"
+    | "orange_background"
+    | "yellow_background"
+    | "green_background"
+    | "blue_background"
+    | "purple_background"
+    | "pink_background"
+    | "red_background"
+}
+
+export type TextRichTextItemResponse = {
+  type: "text"
+  text: { content: string; link: { url: TextRequest } | null }
+  annotations: AnnotationResponse
+  plain_text: string
+  href: string | null
+}
+
+type LinkPreviewMentionResponse = { url: TextRequest }
+
+type TemplateMentionDateTemplateMentionResponse = {
+  type: "template_mention_date"
+  template_mention_date: "today" | "now"
+}
+
+type TemplateMentionUserTemplateMentionResponse = {
+  type: "template_mention_user"
+  template_mention_user: "me"
+}
+
+type TemplateMentionResponse =
+  | TemplateMentionDateTemplateMentionResponse
+  | TemplateMentionUserTemplateMentionResponse
+
+export type MentionRichTextItemResponse = {
+  type: "mention"
+  mention:
+    | { type: "user"; user: PartialUserObjectResponse | UserObjectResponse }
+    | { type: "date"; date: DateResponse }
+    | { type: "link_preview"; link_preview: LinkPreviewMentionResponse }
+    | { type: "template_mention"; template_mention: TemplateMentionResponse }
+    | { type: "page"; page: { id: IdRequest } }
+    | { type: "database"; database: { id: IdRequest } }
+  annotations: AnnotationResponse
+  plain_text: string
+  href: string | null
+}
+
+export type EquationRichTextItemResponse = {
+  type: "equation"
+  equation: { expression: TextRequest }
+  annotations: AnnotationResponse
+  plain_text: string
+  href: string | null
+}
+
+export type RichTextItemResponse =
+  | TextRichTextItemResponse
+  | MentionRichTextItemResponse
+  | EquationRichTextItemResponse
+
+type RollupFunction =
+  | "count"
+  | "count_values"
+  | "empty"
+  | "not_empty"
+  | "unique"
+  | "show_unique"
+  | "percent_empty"
+  | "percent_not_empty"
+  | "sum"
+  | "average"
+  | "median"
+  | "min"
+  | "max"
+  | "range"
+  | "earliest_date"
+  | "latest_date"
+  | "date_range"
+  | "checked"
+  | "unchecked"
+  | "percent_checked"
+  | "percent_unchecked"
+  | "count_per_group"
+  | "percent_per_group"
+  | "show_original"
+
 type EmojiRequest =
   | "😀"
   | "😃"
@@ -3608,15 +4353,91 @@ type EmojiRequest =
   | "🏴󠁧󠁢󠁳󠁣󠁴󠁿"
   | "🏴󠁧󠁢󠁷󠁬󠁳󠁿"
 
-type TextRequest = string
-
 export type PageObjectResponse = {
   parent:
     | { type: "database_id"; database_id: string }
     | { type: "page_id"; page_id: string }
     | { type: "block_id"; block_id: string }
     | { type: "workspace"; workspace: true }
-  properties: Record<string, { id: string }>
+  properties: Record<
+    string,
+    | { type: "number"; number: number | null; id: string }
+    | { type: "url"; url: string | null; id: string }
+    | { type: "select"; select: SelectPropertyResponse | null; id: string }
+    | {
+        type: "multi_select"
+        multi_select: Array<SelectPropertyResponse>
+        id: string
+      }
+    | { type: "status"; status: SelectPropertyResponse | null; id: string }
+    | { type: "date"; date: DateResponse | null; id: string }
+    | { type: "email"; email: string | null; id: string }
+    | { type: "phone_number"; phone_number: string | null; id: string }
+    | { type: "checkbox"; checkbox: boolean; id: string }
+    | {
+        type: "files"
+        files: Array<
+          | {
+              file: { url: string; expiry_time: string }
+              name: StringRequest
+              type?: "file"
+            }
+          | {
+              external: { url: TextRequest }
+              name: StringRequest
+              type?: "external"
+            }
+        >
+        id: string
+      }
+    | {
+        type: "created_by"
+        created_by: PartialUserObjectResponse | UserObjectResponse
+        id: string
+      }
+    | { type: "created_time"; created_time: string; id: string }
+    | {
+        type: "last_edited_by"
+        last_edited_by: PartialUserObjectResponse | UserObjectResponse
+        id: string
+      }
+    | { type: "last_edited_time"; last_edited_time: string; id: string }
+    | { type: "formula"; formula: FormulaPropertyResponse; id: string }
+    | { type: "title"; title: Array<RichTextItemResponse>; id: string }
+    | { type: "rich_text"; rich_text: Array<RichTextItemResponse>; id: string }
+    | {
+        type: "people"
+        people: Array<PartialUserObjectResponse | UserObjectResponse>
+        id: string
+      }
+    | { type: "relation"; relation: Array<{ id: string }>; id: string }
+    | {
+        type: "rollup"
+        rollup:
+          | { type: "number"; number: number | null; function: RollupFunction }
+          | {
+              type: "date"
+              date: DateResponse | null
+              function: RollupFunction
+            }
+          | {
+              type: "array"
+              array: Array<
+                | { type: "title"; title: Array<RichTextItemResponse> }
+                | { type: "rich_text"; rich_text: Array<RichTextItemResponse> }
+                | {
+                    type: "people"
+                    people: Array<
+                      PartialUserObjectResponse | UserObjectResponse
+                    >
+                  }
+                | { type: "relation"; relation: Array<{ id: string }> }
+              >
+              function: RollupFunction
+            }
+        id: string
+      }
+  >
   icon:
     | { type: "emoji"; emoji: EmojiRequest }
     | null
@@ -3695,26 +4516,6 @@ type FormulaDatabasePropertyConfigResponse = {
   name: string
 }
 
-type StringRequest = string
-
-type SelectColor =
-  | "default"
-  | "gray"
-  | "brown"
-  | "orange"
-  | "yellow"
-  | "green"
-  | "blue"
-  | "purple"
-  | "pink"
-  | "red"
-
-type SelectPropertyResponse = {
-  id: StringRequest
-  name: StringRequest
-  color: SelectColor
-}
-
 type SelectDatabasePropertyConfigResponse = {
   type: "select"
   select: { options: Array<SelectPropertyResponse> }
@@ -3729,9 +4530,23 @@ type MultiSelectDatabasePropertyConfigResponse = {
   name: string
 }
 
+type StatusPropertyResponse = {
+  id: StringRequest
+  name: StringRequest
+  color: SelectColor
+}
+
 type StatusDatabasePropertyConfigResponse = {
   type: "status"
-  status: EmptyObject
+  status: {
+    options: Array<StatusPropertyResponse>
+    groups: Array<{
+      id: StringRequest
+      name: StringRequest
+      color: SelectColor
+      option_ids: Array<string>
+    }>
+  }
   id: string
   name: string
 }
@@ -3761,32 +4576,6 @@ type RelationDatabasePropertyConfigResponse = {
   id: string
   name: string
 }
-
-type RollupFunction =
-  | "count"
-  | "count_values"
-  | "empty"
-  | "not_empty"
-  | "unique"
-  | "show_unique"
-  | "percent_empty"
-  | "percent_not_empty"
-  | "sum"
-  | "average"
-  | "median"
-  | "min"
-  | "max"
-  | "range"
-  | "earliest_date"
-  | "latest_date"
-  | "date_range"
-  | "checked"
-  | "unchecked"
-  | "percent_checked"
-  | "percent_unchecked"
-  | "count_per_group"
-  | "percent_per_group"
-  | "show_original"
 
 type RollupDatabasePropertyConfigResponse = {
   type: "rollup"
@@ -3919,686 +4708,6 @@ export type PartialDatabaseObjectResponse = {
   id: string
   properties: Record<string, DatabasePropertyConfigResponse>
 }
-
-type AnnotationResponse = {
-  bold: boolean
-  italic: boolean
-  strikethrough: boolean
-  underline: boolean
-  code: boolean
-  color:
-    | "default"
-    | "gray"
-    | "brown"
-    | "orange"
-    | "yellow"
-    | "green"
-    | "blue"
-    | "purple"
-    | "pink"
-    | "red"
-    | "gray_background"
-    | "brown_background"
-    | "orange_background"
-    | "yellow_background"
-    | "green_background"
-    | "blue_background"
-    | "purple_background"
-    | "pink_background"
-    | "red_background"
-}
-
-export type TextRichTextItemResponse = {
-  type: "text"
-  text: { content: string; link: { url: TextRequest } | null }
-  annotations: AnnotationResponse
-  plain_text: string
-  href: string | null
-}
-
-type TimeZoneRequest =
-  | "Africa/Abidjan"
-  | "Africa/Accra"
-  | "Africa/Addis_Ababa"
-  | "Africa/Algiers"
-  | "Africa/Asmara"
-  | "Africa/Asmera"
-  | "Africa/Bamako"
-  | "Africa/Bangui"
-  | "Africa/Banjul"
-  | "Africa/Bissau"
-  | "Africa/Blantyre"
-  | "Africa/Brazzaville"
-  | "Africa/Bujumbura"
-  | "Africa/Cairo"
-  | "Africa/Casablanca"
-  | "Africa/Ceuta"
-  | "Africa/Conakry"
-  | "Africa/Dakar"
-  | "Africa/Dar_es_Salaam"
-  | "Africa/Djibouti"
-  | "Africa/Douala"
-  | "Africa/El_Aaiun"
-  | "Africa/Freetown"
-  | "Africa/Gaborone"
-  | "Africa/Harare"
-  | "Africa/Johannesburg"
-  | "Africa/Juba"
-  | "Africa/Kampala"
-  | "Africa/Khartoum"
-  | "Africa/Kigali"
-  | "Africa/Kinshasa"
-  | "Africa/Lagos"
-  | "Africa/Libreville"
-  | "Africa/Lome"
-  | "Africa/Luanda"
-  | "Africa/Lubumbashi"
-  | "Africa/Lusaka"
-  | "Africa/Malabo"
-  | "Africa/Maputo"
-  | "Africa/Maseru"
-  | "Africa/Mbabane"
-  | "Africa/Mogadishu"
-  | "Africa/Monrovia"
-  | "Africa/Nairobi"
-  | "Africa/Ndjamena"
-  | "Africa/Niamey"
-  | "Africa/Nouakchott"
-  | "Africa/Ouagadougou"
-  | "Africa/Porto-Novo"
-  | "Africa/Sao_Tome"
-  | "Africa/Timbuktu"
-  | "Africa/Tripoli"
-  | "Africa/Tunis"
-  | "Africa/Windhoek"
-  | "America/Adak"
-  | "America/Anchorage"
-  | "America/Anguilla"
-  | "America/Antigua"
-  | "America/Araguaina"
-  | "America/Argentina/Buenos_Aires"
-  | "America/Argentina/Catamarca"
-  | "America/Argentina/ComodRivadavia"
-  | "America/Argentina/Cordoba"
-  | "America/Argentina/Jujuy"
-  | "America/Argentina/La_Rioja"
-  | "America/Argentina/Mendoza"
-  | "America/Argentina/Rio_Gallegos"
-  | "America/Argentina/Salta"
-  | "America/Argentina/San_Juan"
-  | "America/Argentina/San_Luis"
-  | "America/Argentina/Tucuman"
-  | "America/Argentina/Ushuaia"
-  | "America/Aruba"
-  | "America/Asuncion"
-  | "America/Atikokan"
-  | "America/Atka"
-  | "America/Bahia"
-  | "America/Bahia_Banderas"
-  | "America/Barbados"
-  | "America/Belem"
-  | "America/Belize"
-  | "America/Blanc-Sablon"
-  | "America/Boa_Vista"
-  | "America/Bogota"
-  | "America/Boise"
-  | "America/Buenos_Aires"
-  | "America/Cambridge_Bay"
-  | "America/Campo_Grande"
-  | "America/Cancun"
-  | "America/Caracas"
-  | "America/Catamarca"
-  | "America/Cayenne"
-  | "America/Cayman"
-  | "America/Chicago"
-  | "America/Chihuahua"
-  | "America/Coral_Harbour"
-  | "America/Cordoba"
-  | "America/Costa_Rica"
-  | "America/Creston"
-  | "America/Cuiaba"
-  | "America/Curacao"
-  | "America/Danmarkshavn"
-  | "America/Dawson"
-  | "America/Dawson_Creek"
-  | "America/Denver"
-  | "America/Detroit"
-  | "America/Dominica"
-  | "America/Edmonton"
-  | "America/Eirunepe"
-  | "America/El_Salvador"
-  | "America/Ensenada"
-  | "America/Fort_Nelson"
-  | "America/Fort_Wayne"
-  | "America/Fortaleza"
-  | "America/Glace_Bay"
-  | "America/Godthab"
-  | "America/Goose_Bay"
-  | "America/Grand_Turk"
-  | "America/Grenada"
-  | "America/Guadeloupe"
-  | "America/Guatemala"
-  | "America/Guayaquil"
-  | "America/Guyana"
-  | "America/Halifax"
-  | "America/Havana"
-  | "America/Hermosillo"
-  | "America/Indiana/Indianapolis"
-  | "America/Indiana/Knox"
-  | "America/Indiana/Marengo"
-  | "America/Indiana/Petersburg"
-  | "America/Indiana/Tell_City"
-  | "America/Indiana/Vevay"
-  | "America/Indiana/Vincennes"
-  | "America/Indiana/Winamac"
-  | "America/Indianapolis"
-  | "America/Inuvik"
-  | "America/Iqaluit"
-  | "America/Jamaica"
-  | "America/Jujuy"
-  | "America/Juneau"
-  | "America/Kentucky/Louisville"
-  | "America/Kentucky/Monticello"
-  | "America/Knox_IN"
-  | "America/Kralendijk"
-  | "America/La_Paz"
-  | "America/Lima"
-  | "America/Los_Angeles"
-  | "America/Louisville"
-  | "America/Lower_Princes"
-  | "America/Maceio"
-  | "America/Managua"
-  | "America/Manaus"
-  | "America/Marigot"
-  | "America/Martinique"
-  | "America/Matamoros"
-  | "America/Mazatlan"
-  | "America/Mendoza"
-  | "America/Menominee"
-  | "America/Merida"
-  | "America/Metlakatla"
-  | "America/Mexico_City"
-  | "America/Miquelon"
-  | "America/Moncton"
-  | "America/Monterrey"
-  | "America/Montevideo"
-  | "America/Montreal"
-  | "America/Montserrat"
-  | "America/Nassau"
-  | "America/New_York"
-  | "America/Nipigon"
-  | "America/Nome"
-  | "America/Noronha"
-  | "America/North_Dakota/Beulah"
-  | "America/North_Dakota/Center"
-  | "America/North_Dakota/New_Salem"
-  | "America/Ojinaga"
-  | "America/Panama"
-  | "America/Pangnirtung"
-  | "America/Paramaribo"
-  | "America/Phoenix"
-  | "America/Port-au-Prince"
-  | "America/Port_of_Spain"
-  | "America/Porto_Acre"
-  | "America/Porto_Velho"
-  | "America/Puerto_Rico"
-  | "America/Punta_Arenas"
-  | "America/Rainy_River"
-  | "America/Rankin_Inlet"
-  | "America/Recife"
-  | "America/Regina"
-  | "America/Resolute"
-  | "America/Rio_Branco"
-  | "America/Rosario"
-  | "America/Santa_Isabel"
-  | "America/Santarem"
-  | "America/Santiago"
-  | "America/Santo_Domingo"
-  | "America/Sao_Paulo"
-  | "America/Scoresbysund"
-  | "America/Shiprock"
-  | "America/Sitka"
-  | "America/St_Barthelemy"
-  | "America/St_Johns"
-  | "America/St_Kitts"
-  | "America/St_Lucia"
-  | "America/St_Thomas"
-  | "America/St_Vincent"
-  | "America/Swift_Current"
-  | "America/Tegucigalpa"
-  | "America/Thule"
-  | "America/Thunder_Bay"
-  | "America/Tijuana"
-  | "America/Toronto"
-  | "America/Tortola"
-  | "America/Vancouver"
-  | "America/Virgin"
-  | "America/Whitehorse"
-  | "America/Winnipeg"
-  | "America/Yakutat"
-  | "America/Yellowknife"
-  | "Antarctica/Casey"
-  | "Antarctica/Davis"
-  | "Antarctica/DumontDUrville"
-  | "Antarctica/Macquarie"
-  | "Antarctica/Mawson"
-  | "Antarctica/McMurdo"
-  | "Antarctica/Palmer"
-  | "Antarctica/Rothera"
-  | "Antarctica/South_Pole"
-  | "Antarctica/Syowa"
-  | "Antarctica/Troll"
-  | "Antarctica/Vostok"
-  | "Arctic/Longyearbyen"
-  | "Asia/Aden"
-  | "Asia/Almaty"
-  | "Asia/Amman"
-  | "Asia/Anadyr"
-  | "Asia/Aqtau"
-  | "Asia/Aqtobe"
-  | "Asia/Ashgabat"
-  | "Asia/Ashkhabad"
-  | "Asia/Atyrau"
-  | "Asia/Baghdad"
-  | "Asia/Bahrain"
-  | "Asia/Baku"
-  | "Asia/Bangkok"
-  | "Asia/Barnaul"
-  | "Asia/Beirut"
-  | "Asia/Bishkek"
-  | "Asia/Brunei"
-  | "Asia/Calcutta"
-  | "Asia/Chita"
-  | "Asia/Choibalsan"
-  | "Asia/Chongqing"
-  | "Asia/Chungking"
-  | "Asia/Colombo"
-  | "Asia/Dacca"
-  | "Asia/Damascus"
-  | "Asia/Dhaka"
-  | "Asia/Dili"
-  | "Asia/Dubai"
-  | "Asia/Dushanbe"
-  | "Asia/Famagusta"
-  | "Asia/Gaza"
-  | "Asia/Harbin"
-  | "Asia/Hebron"
-  | "Asia/Ho_Chi_Minh"
-  | "Asia/Hong_Kong"
-  | "Asia/Hovd"
-  | "Asia/Irkutsk"
-  | "Asia/Istanbul"
-  | "Asia/Jakarta"
-  | "Asia/Jayapura"
-  | "Asia/Jerusalem"
-  | "Asia/Kabul"
-  | "Asia/Kamchatka"
-  | "Asia/Karachi"
-  | "Asia/Kashgar"
-  | "Asia/Kathmandu"
-  | "Asia/Katmandu"
-  | "Asia/Khandyga"
-  | "Asia/Kolkata"
-  | "Asia/Krasnoyarsk"
-  | "Asia/Kuala_Lumpur"
-  | "Asia/Kuching"
-  | "Asia/Kuwait"
-  | "Asia/Macao"
-  | "Asia/Macau"
-  | "Asia/Magadan"
-  | "Asia/Makassar"
-  | "Asia/Manila"
-  | "Asia/Muscat"
-  | "Asia/Nicosia"
-  | "Asia/Novokuznetsk"
-  | "Asia/Novosibirsk"
-  | "Asia/Omsk"
-  | "Asia/Oral"
-  | "Asia/Phnom_Penh"
-  | "Asia/Pontianak"
-  | "Asia/Pyongyang"
-  | "Asia/Qatar"
-  | "Asia/Qostanay"
-  | "Asia/Qyzylorda"
-  | "Asia/Rangoon"
-  | "Asia/Riyadh"
-  | "Asia/Saigon"
-  | "Asia/Sakhalin"
-  | "Asia/Samarkand"
-  | "Asia/Seoul"
-  | "Asia/Shanghai"
-  | "Asia/Singapore"
-  | "Asia/Srednekolymsk"
-  | "Asia/Taipei"
-  | "Asia/Tashkent"
-  | "Asia/Tbilisi"
-  | "Asia/Tehran"
-  | "Asia/Tel_Aviv"
-  | "Asia/Thimbu"
-  | "Asia/Thimphu"
-  | "Asia/Tokyo"
-  | "Asia/Tomsk"
-  | "Asia/Ujung_Pandang"
-  | "Asia/Ulaanbaatar"
-  | "Asia/Ulan_Bator"
-  | "Asia/Urumqi"
-  | "Asia/Ust-Nera"
-  | "Asia/Vientiane"
-  | "Asia/Vladivostok"
-  | "Asia/Yakutsk"
-  | "Asia/Yangon"
-  | "Asia/Yekaterinburg"
-  | "Asia/Yerevan"
-  | "Atlantic/Azores"
-  | "Atlantic/Bermuda"
-  | "Atlantic/Canary"
-  | "Atlantic/Cape_Verde"
-  | "Atlantic/Faeroe"
-  | "Atlantic/Faroe"
-  | "Atlantic/Jan_Mayen"
-  | "Atlantic/Madeira"
-  | "Atlantic/Reykjavik"
-  | "Atlantic/South_Georgia"
-  | "Atlantic/St_Helena"
-  | "Atlantic/Stanley"
-  | "Australia/ACT"
-  | "Australia/Adelaide"
-  | "Australia/Brisbane"
-  | "Australia/Broken_Hill"
-  | "Australia/Canberra"
-  | "Australia/Currie"
-  | "Australia/Darwin"
-  | "Australia/Eucla"
-  | "Australia/Hobart"
-  | "Australia/LHI"
-  | "Australia/Lindeman"
-  | "Australia/Lord_Howe"
-  | "Australia/Melbourne"
-  | "Australia/NSW"
-  | "Australia/North"
-  | "Australia/Perth"
-  | "Australia/Queensland"
-  | "Australia/South"
-  | "Australia/Sydney"
-  | "Australia/Tasmania"
-  | "Australia/Victoria"
-  | "Australia/West"
-  | "Australia/Yancowinna"
-  | "Brazil/Acre"
-  | "Brazil/DeNoronha"
-  | "Brazil/East"
-  | "Brazil/West"
-  | "CET"
-  | "CST6CDT"
-  | "Canada/Atlantic"
-  | "Canada/Central"
-  | "Canada/Eastern"
-  | "Canada/Mountain"
-  | "Canada/Newfoundland"
-  | "Canada/Pacific"
-  | "Canada/Saskatchewan"
-  | "Canada/Yukon"
-  | "Chile/Continental"
-  | "Chile/EasterIsland"
-  | "Cuba"
-  | "EET"
-  | "EST"
-  | "EST5EDT"
-  | "Egypt"
-  | "Eire"
-  | "Etc/GMT"
-  | "Etc/GMT+0"
-  | "Etc/GMT+1"
-  | "Etc/GMT+10"
-  | "Etc/GMT+11"
-  | "Etc/GMT+12"
-  | "Etc/GMT+2"
-  | "Etc/GMT+3"
-  | "Etc/GMT+4"
-  | "Etc/GMT+5"
-  | "Etc/GMT+6"
-  | "Etc/GMT+7"
-  | "Etc/GMT+8"
-  | "Etc/GMT+9"
-  | "Etc/GMT-0"
-  | "Etc/GMT-1"
-  | "Etc/GMT-10"
-  | "Etc/GMT-11"
-  | "Etc/GMT-12"
-  | "Etc/GMT-13"
-  | "Etc/GMT-14"
-  | "Etc/GMT-2"
-  | "Etc/GMT-3"
-  | "Etc/GMT-4"
-  | "Etc/GMT-5"
-  | "Etc/GMT-6"
-  | "Etc/GMT-7"
-  | "Etc/GMT-8"
-  | "Etc/GMT-9"
-  | "Etc/GMT0"
-  | "Etc/Greenwich"
-  | "Etc/UCT"
-  | "Etc/UTC"
-  | "Etc/Universal"
-  | "Etc/Zulu"
-  | "Europe/Amsterdam"
-  | "Europe/Andorra"
-  | "Europe/Astrakhan"
-  | "Europe/Athens"
-  | "Europe/Belfast"
-  | "Europe/Belgrade"
-  | "Europe/Berlin"
-  | "Europe/Bratislava"
-  | "Europe/Brussels"
-  | "Europe/Bucharest"
-  | "Europe/Budapest"
-  | "Europe/Busingen"
-  | "Europe/Chisinau"
-  | "Europe/Copenhagen"
-  | "Europe/Dublin"
-  | "Europe/Gibraltar"
-  | "Europe/Guernsey"
-  | "Europe/Helsinki"
-  | "Europe/Isle_of_Man"
-  | "Europe/Istanbul"
-  | "Europe/Jersey"
-  | "Europe/Kaliningrad"
-  | "Europe/Kiev"
-  | "Europe/Kirov"
-  | "Europe/Lisbon"
-  | "Europe/Ljubljana"
-  | "Europe/London"
-  | "Europe/Luxembourg"
-  | "Europe/Madrid"
-  | "Europe/Malta"
-  | "Europe/Mariehamn"
-  | "Europe/Minsk"
-  | "Europe/Monaco"
-  | "Europe/Moscow"
-  | "Europe/Nicosia"
-  | "Europe/Oslo"
-  | "Europe/Paris"
-  | "Europe/Podgorica"
-  | "Europe/Prague"
-  | "Europe/Riga"
-  | "Europe/Rome"
-  | "Europe/Samara"
-  | "Europe/San_Marino"
-  | "Europe/Sarajevo"
-  | "Europe/Saratov"
-  | "Europe/Simferopol"
-  | "Europe/Skopje"
-  | "Europe/Sofia"
-  | "Europe/Stockholm"
-  | "Europe/Tallinn"
-  | "Europe/Tirane"
-  | "Europe/Tiraspol"
-  | "Europe/Ulyanovsk"
-  | "Europe/Uzhgorod"
-  | "Europe/Vaduz"
-  | "Europe/Vatican"
-  | "Europe/Vienna"
-  | "Europe/Vilnius"
-  | "Europe/Volgograd"
-  | "Europe/Warsaw"
-  | "Europe/Zagreb"
-  | "Europe/Zaporozhye"
-  | "Europe/Zurich"
-  | "GB"
-  | "GB-Eire"
-  | "GMT"
-  | "GMT+0"
-  | "GMT-0"
-  | "GMT0"
-  | "Greenwich"
-  | "HST"
-  | "Hongkong"
-  | "Iceland"
-  | "Indian/Antananarivo"
-  | "Indian/Chagos"
-  | "Indian/Christmas"
-  | "Indian/Cocos"
-  | "Indian/Comoro"
-  | "Indian/Kerguelen"
-  | "Indian/Mahe"
-  | "Indian/Maldives"
-  | "Indian/Mauritius"
-  | "Indian/Mayotte"
-  | "Indian/Reunion"
-  | "Iran"
-  | "Israel"
-  | "Jamaica"
-  | "Japan"
-  | "Kwajalein"
-  | "Libya"
-  | "MET"
-  | "MST"
-  | "MST7MDT"
-  | "Mexico/BajaNorte"
-  | "Mexico/BajaSur"
-  | "Mexico/General"
-  | "NZ"
-  | "NZ-CHAT"
-  | "Navajo"
-  | "PRC"
-  | "PST8PDT"
-  | "Pacific/Apia"
-  | "Pacific/Auckland"
-  | "Pacific/Bougainville"
-  | "Pacific/Chatham"
-  | "Pacific/Chuuk"
-  | "Pacific/Easter"
-  | "Pacific/Efate"
-  | "Pacific/Enderbury"
-  | "Pacific/Fakaofo"
-  | "Pacific/Fiji"
-  | "Pacific/Funafuti"
-  | "Pacific/Galapagos"
-  | "Pacific/Gambier"
-  | "Pacific/Guadalcanal"
-  | "Pacific/Guam"
-  | "Pacific/Honolulu"
-  | "Pacific/Johnston"
-  | "Pacific/Kiritimati"
-  | "Pacific/Kosrae"
-  | "Pacific/Kwajalein"
-  | "Pacific/Majuro"
-  | "Pacific/Marquesas"
-  | "Pacific/Midway"
-  | "Pacific/Nauru"
-  | "Pacific/Niue"
-  | "Pacific/Norfolk"
-  | "Pacific/Noumea"
-  | "Pacific/Pago_Pago"
-  | "Pacific/Palau"
-  | "Pacific/Pitcairn"
-  | "Pacific/Pohnpei"
-  | "Pacific/Ponape"
-  | "Pacific/Port_Moresby"
-  | "Pacific/Rarotonga"
-  | "Pacific/Saipan"
-  | "Pacific/Samoa"
-  | "Pacific/Tahiti"
-  | "Pacific/Tarawa"
-  | "Pacific/Tongatapu"
-  | "Pacific/Truk"
-  | "Pacific/Wake"
-  | "Pacific/Wallis"
-  | "Pacific/Yap"
-  | "Poland"
-  | "Portugal"
-  | "ROC"
-  | "ROK"
-  | "Singapore"
-  | "Turkey"
-  | "UCT"
-  | "US/Alaska"
-  | "US/Aleutian"
-  | "US/Arizona"
-  | "US/Central"
-  | "US/East-Indiana"
-  | "US/Eastern"
-  | "US/Hawaii"
-  | "US/Indiana-Starke"
-  | "US/Michigan"
-  | "US/Mountain"
-  | "US/Pacific"
-  | "US/Pacific-New"
-  | "US/Samoa"
-  | "UTC"
-  | "Universal"
-  | "W-SU"
-  | "WET"
-  | "Zulu"
-
-type DateResponse = {
-  start: string
-  end: string | null
-  time_zone: TimeZoneRequest | null
-}
-
-type LinkPreviewMentionResponse = { url: TextRequest }
-
-type TemplateMentionDateTemplateMentionResponse = {
-  type: "template_mention_date"
-  template_mention_date: "today" | "now"
-}
-
-type TemplateMentionUserTemplateMentionResponse = {
-  type: "template_mention_user"
-  template_mention_user: "me"
-}
-
-type TemplateMentionResponse =
-  | TemplateMentionDateTemplateMentionResponse
-  | TemplateMentionUserTemplateMentionResponse
-
-export type MentionRichTextItemResponse = {
-  type: "mention"
-  mention:
-    | { type: "user"; user: PartialUserObjectResponse | UserObjectResponse }
-    | { type: "date"; date: DateResponse }
-    | { type: "link_preview"; link_preview: LinkPreviewMentionResponse }
-    | { type: "template_mention"; template_mention: TemplateMentionResponse }
-    | { type: "page"; page: { id: IdRequest } }
-    | { type: "database"; database: { id: IdRequest } }
-  annotations: AnnotationResponse
-  plain_text: string
-  href: string | null
-}
-
-export type EquationRichTextItemResponse = {
-  type: "equation"
-  equation: { expression: TextRequest }
-  annotations: AnnotationResponse
-  plain_text: string
-  href: string | null
-}
-
-export type RichTextItemResponse =
-  | TextRichTextItemResponse
-  | MentionRichTextItemResponse
-  | EquationRichTextItemResponse
 
 export type DatabaseObjectResponse = {
   title: Array<RichTextItemResponse>
@@ -4920,24 +5029,30 @@ export type EquationBlockObjectResponse = {
 
 type LanguageRequest =
   | "abap"
+  | "agda"
   | "arduino"
+  | "assembly"
   | "bash"
   | "basic"
+  | "bnf"
   | "c"
+  | "c#"
+  | "c++"
   | "clojure"
   | "coffeescript"
-  | "c++"
-  | "c#"
+  | "coq"
   | "css"
   | "dart"
+  | "dhall"
   | "diff"
   | "docker"
+  | "ebnf"
   | "elixir"
   | "elm"
   | "erlang"
+  | "f#"
   | "flow"
   | "fortran"
-  | "f#"
   | "gherkin"
   | "glsl"
   | "go"
@@ -4945,6 +5060,7 @@ type LanguageRequest =
   | "groovy"
   | "haskell"
   | "html"
+  | "idris"
   | "java"
   | "javascript"
   | "json"
@@ -4954,11 +5070,13 @@ type LanguageRequest =
   | "less"
   | "lisp"
   | "livescript"
+  | "llvm ir"
   | "lua"
   | "makefile"
   | "markdown"
   | "markup"
   | "matlab"
+  | "mathematica"
   | "mermaid"
   | "nix"
   | "objective-c"
@@ -4970,8 +5088,10 @@ type LanguageRequest =
   | "powershell"
   | "prolog"
   | "protobuf"
+  | "purescript"
   | "python"
   | "r"
+  | "racket"
   | "reason"
   | "ruby"
   | "rust"
@@ -4983,6 +5103,7 @@ type LanguageRequest =
   | "solidity"
   | "sql"
   | "swift"
+  | "toml"
   | "typescript"
   | "vb.net"
   | "verilog"
@@ -5545,23 +5666,6 @@ export type LastEditedTimePropertyItemObjectResponse = {
   id: string
 }
 
-type StringFormulaPropertyResponse = { type: "string"; string: string | null }
-
-type DateFormulaPropertyResponse = { type: "date"; date: DateResponse | null }
-
-type NumberFormulaPropertyResponse = { type: "number"; number: number | null }
-
-type BooleanFormulaPropertyResponse = {
-  type: "boolean"
-  boolean: boolean | null
-}
-
-type FormulaPropertyResponse =
-  | StringFormulaPropertyResponse
-  | DateFormulaPropertyResponse
-  | NumberFormulaPropertyResponse
-  | BooleanFormulaPropertyResponse
-
 export type FormulaPropertyItemObjectResponse = {
   type: "formula"
   formula: FormulaPropertyResponse
@@ -5935,17 +6039,29 @@ type BlockObjectRequestWithoutChildren =
       object?: "block"
     }
   | {
-      heading_1: { rich_text: Array<RichTextItemRequest>; color?: ApiColor }
+      heading_1: {
+        rich_text: Array<RichTextItemRequest>
+        color?: ApiColor
+        is_toggleable?: boolean
+      }
       type?: "heading_1"
       object?: "block"
     }
   | {
-      heading_2: { rich_text: Array<RichTextItemRequest>; color?: ApiColor }
+      heading_2: {
+        rich_text: Array<RichTextItemRequest>
+        color?: ApiColor
+        is_toggleable?: boolean
+      }
       type?: "heading_2"
       object?: "block"
     }
   | {
-      heading_3: { rich_text: Array<RichTextItemRequest>; color?: ApiColor }
+      heading_3: {
+        rich_text: Array<RichTextItemRequest>
+        color?: ApiColor
+        is_toggleable?: boolean
+      }
       type?: "heading_3"
       object?: "block"
     }
@@ -6202,6 +6318,7 @@ type BlockObjectRequest =
                   heading_1: {
                     rich_text: Array<RichTextItemRequest>
                     color?: ApiColor
+                    is_toggleable?: boolean
                     children?: Array<BlockObjectRequestWithoutChildren>
                   }
                   type?: "heading_1"
@@ -6211,6 +6328,7 @@ type BlockObjectRequest =
                   heading_2: {
                     rich_text: Array<RichTextItemRequest>
                     color?: ApiColor
+                    is_toggleable?: boolean
                     children?: Array<BlockObjectRequestWithoutChildren>
                   }
                   type?: "heading_2"
@@ -6220,6 +6338,7 @@ type BlockObjectRequest =
                   heading_3: {
                     rich_text: Array<RichTextItemRequest>
                     color?: ApiColor
+                    is_toggleable?: boolean
                     children?: Array<BlockObjectRequestWithoutChildren>
                   }
                   type?: "heading_3"
@@ -6415,6 +6534,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -6424,6 +6544,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -6433,6 +6554,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -6540,6 +6662,7 @@ type BlockObjectRequest =
       heading_1: {
         rich_text: Array<RichTextItemRequest>
         color?: ApiColor
+        is_toggleable?: boolean
         children?: Array<
           | {
               embed: { url: string; caption?: Array<RichTextItemRequest> }
@@ -6633,6 +6756,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -6642,6 +6766,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -6651,6 +6776,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -6748,6 +6874,7 @@ type BlockObjectRequest =
       heading_2: {
         rich_text: Array<RichTextItemRequest>
         color?: ApiColor
+        is_toggleable?: boolean
         children?: Array<
           | {
               embed: { url: string; caption?: Array<RichTextItemRequest> }
@@ -6841,6 +6968,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -6850,6 +6978,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -6859,6 +6988,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -6956,6 +7086,7 @@ type BlockObjectRequest =
       heading_3: {
         rich_text: Array<RichTextItemRequest>
         color?: ApiColor
+        is_toggleable?: boolean
         children?: Array<
           | {
               embed: { url: string; caption?: Array<RichTextItemRequest> }
@@ -7049,6 +7180,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -7058,6 +7190,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -7067,6 +7200,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -7257,6 +7391,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -7266,6 +7401,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -7275,6 +7411,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -7465,6 +7602,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -7474,6 +7612,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -7483,6 +7622,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -7673,6 +7813,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -7682,6 +7823,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -7691,6 +7833,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -7881,6 +8024,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -7890,6 +8034,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -7899,6 +8044,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -8089,6 +8235,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -8098,6 +8245,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -8107,6 +8255,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -8298,6 +8447,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -8307,6 +8457,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -8316,6 +8467,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -8505,6 +8657,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -8514,6 +8667,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -8523,6 +8677,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -8713,6 +8868,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -8722,6 +8878,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -8731,6 +8888,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -8923,6 +9081,7 @@ type BlockObjectRequest =
               heading_1: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_1"
@@ -8932,6 +9091,7 @@ type BlockObjectRequest =
               heading_2: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_2"
@@ -8941,6 +9101,7 @@ type BlockObjectRequest =
               heading_3: {
                 rich_text: Array<RichTextItemRequest>
                 color?: ApiColor
+                is_toggleable?: boolean
                 children?: Array<BlockObjectRequestWithoutChildren>
               }
               type?: "heading_3"
@@ -9067,6 +9228,11 @@ type MultiSelectPropertyFilter =
   | { does_not_contain: string }
   | ExistencePropertyFilter
 
+type StatusPropertyFilter =
+  | { equals: string }
+  | { does_not_equal: string }
+  | ExistencePropertyFilter
+
 type DatePropertyFilter =
   | { equals: string }
   | { before: string }
@@ -9126,6 +9292,7 @@ type PropertyFilter =
       property: string
       type?: "multi_select"
     }
+  | { status: StatusPropertyFilter; property: string; type?: "status" }
   | { date: DatePropertyFilter; property: string; type?: "date" }
   | { people: PeoplePropertyFilter; property: string; type?: "people" }
   | { files: ExistencePropertyFilter; property: string; type?: "files" }
@@ -9320,6 +9487,22 @@ type CreatePageBodyParameters =
                 >
                 type?: "files"
               }
+            | {
+                status:
+                  | {
+                      id: StringRequest
+                      name?: StringRequest
+                      color?: SelectColor
+                    }
+                  | null
+                  | {
+                      name: StringRequest
+                      id?: StringRequest
+                      color?: SelectColor
+                    }
+                  | null
+                type?: "status"
+              }
           >
         | Record<
             string,
@@ -9402,6 +9585,10 @@ type CreatePageBodyParameters =
                     type?: "external"
                   }
               >
+            | { id: StringRequest; name?: StringRequest; color?: SelectColor }
+            | null
+            | { name: StringRequest; id?: StringRequest; color?: SelectColor }
+            | null
           >
       icon?:
         | { emoji: EmojiRequest; type?: "emoji" }
@@ -9543,6 +9730,14 @@ type UpdatePageBodyParameters = {
             >
             type?: "files"
           }
+        | {
+            status:
+              | { id: StringRequest; name?: StringRequest; color?: SelectColor }
+              | null
+              | { name: StringRequest; id?: StringRequest; color?: SelectColor }
+              | null
+            type?: "status"
+          }
       >
     | Record<
         string,
@@ -9617,6 +9812,10 @@ type UpdatePageBodyParameters = {
                 type?: "external"
               }
           >
+        | { id: StringRequest; name?: StringRequest; color?: SelectColor }
+        | null
+        | { name: StringRequest; id?: StringRequest; color?: SelectColor }
+        | null
       >
   icon?:
     | { emoji: EmojiRequest; type?: "emoji" }
@@ -9767,17 +9966,29 @@ type UpdateBlockBodyParameters =
       archived?: boolean
     }
   | {
-      heading_1: { rich_text: Array<RichTextItemRequest>; color?: ApiColor }
+      heading_1: {
+        rich_text: Array<RichTextItemRequest>
+        color?: ApiColor
+        is_toggleable?: boolean
+      }
       type?: "heading_1"
       archived?: boolean
     }
   | {
-      heading_2: { rich_text: Array<RichTextItemRequest>; color?: ApiColor }
+      heading_2: {
+        rich_text: Array<RichTextItemRequest>
+        color?: ApiColor
+        is_toggleable?: boolean
+      }
       type?: "heading_2"
       archived?: boolean
     }
   | {
-      heading_3: { rich_text: Array<RichTextItemRequest>; color?: ApiColor }
+      heading_3: {
+        rich_text: Array<RichTextItemRequest>
+        color?: ApiColor
+        is_toggleable?: boolean
+      }
       type?: "heading_3"
       archived?: boolean
     }


### PR DESCRIPTION
## Status property
Now supported! [See API changelog](https://developers.notion.com/changelog/changes-for-august-15-28-2022)

## Toggle headers
Now supported! [See API changelog](https://developers.notion.com/changelog/changes-for-august-15-28-2022)

## Page properties
Previously, responses that included page property data would not include page property types or values. This behavior impacted retrieving pages, querying databases, and searching. With this change, page properties will now include types and values in the response, which matches the behavior in version `2022-02-22` of the Notion API.

[See API changelog](https://developers.notion.com/changelog/changes-for-august-31-2022)