### PR TITLE
update api for page create to include parent page_id

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -9407,7 +9407,7 @@ export const listUsers = {
 
 type CreatePageBodyParameters =
   | {
-      parent: { database_id: IdRequest; type?: "database_id" }
+      parent: { database_id: IdRequest; type?: "database_id" } | { page_id: IdRequest; type?: "page_id" }
       properties:
         | Record<
             string,


### PR DESCRIPTION
the default params for creating a page in the docs indicate a database or parent page are acceptible. as the types stand they only accept a database id and require a cast. this is modeled after the other places that include this, such as the UpdatePageBodyParamters directly under this one.