### PR TITLE
 add some more type exports

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -5956,7 +5956,7 @@ type RichTextItemRequest =
       }
     }
 
-type BlockObjectRequestWithoutChildren =
+export type BlockObjectRequestWithoutChildren =
   | {
       embed: { url: string; caption?: Array<RichTextItemRequest> }
       type?: "embed"
@@ -6133,7 +6133,7 @@ type BlockObjectRequestWithoutChildren =
       object?: "block"
     }
 
-type BlockObjectRequest =
+export type BlockObjectRequest =
   | {
       embed: { url: string; caption?: Array<RichTextItemRequest> }
       type?: "embed"


### PR DESCRIPTION
hello again! i'm taking another shot at updating these types, as of today, the request api objects aren't exported, so if you want to get them you gotta do illegal stuff like this:

```ts
import { AppendBlockChildrenParameters } from '@notionhq/client/build/src/api-endpoints';

type Unarray<T> = T extends Array<infer U> ? U : T;

export type DerivedBlockRequest = Unarray<AppendBlockChildrenParameters["children"]>
```

i'd really like to just export these in the same way that `BlockObjectResponse` is