### PR TITLE
Ignore VS Code settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ package-lock.json
 /examples/**/package-lock.json
 /examples/**/.env
 
-
+.vscode
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cSpell.words": ["notionhq"]
-}


### PR DESCRIPTION
Seems the `.vscode` directory can be ignored. We already have `.cspell.json` in our project and they support `.cspell.json` as the configuration file in VS Code:

See https://github.com/streetsidesoftware/vscode-spell-checker/blob/add7ae9b37b7d02eadfbd2788ab0b0d6699e09d6/packages/client/src/settings/CSpellSettings.ts#L11-L13.

On the other hand, ignoring the `.vscode` directory can let developers put their editor settings. They can decide to enable or disable specific extension settings for specific projects.

Currently, we don't have other editor settings like `.vscode/launch.json`, `.vscode/tasks.json`, etc. So it's OK to ignore the whole directory.

We could change the rule if we need to put some other project-level configuration files in the `.vscode` directory in the future.