### PR TITLE
2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
Follow-up from #366 for `filter_properties` query param.

Q: I have created the 2.2.3 tag and pushed it to GitHub, but I don't see it associated with my commit here. Is that expected?