### PR TITLE
Update example README instructions to include integration access note

### DIFF
--- a/examples/database-email-update/README.md
+++ b/examples/database-email-update/README.md
@@ -24,7 +24,7 @@ npm install
 ### 2. Set your environment variables in a `.env` file
 
 ```zsh
-NOTION_KEY= <your-notion-api-key>
+NOTION_KEY=<your-notion-api-key>
 SENDGRID_KEY=<your-sendgrid-api-key>
 NOTION_DATABASE_ID=<your-notion-database-id>
 EMAIL_TO_FIELD=<email-recipients>
@@ -36,6 +36,8 @@ You can create your Notion API key [here](https://www.notion.com/my-integrations
 You can create your SendGrid API key [here](https://signup.sendgrid.com).
 
 To create a Notion database that will work with this example, duplicate [this template](https://www.notion.com/5b593126d3eb401db62c83cbe362d2d5?v=a44397b3675545f389a6f28282c402ae).
+
+Your Notion integration will need access to the Notion database you have created. To provide access, follow the instructions found in Notion's [Integration guide](https://developers.notion.com/docs/create-a-notion-integration#step-2-share-a-database-with-your-integration).
 
 ### 3. Run code
 

--- a/examples/notion-github-sync/README.md
+++ b/examples/notion-github-sync/README.md
@@ -37,6 +37,8 @@ You can create your GitHub Personal Access token by following the guide [here](h
 
 To create a Notion database that will work with this example, duplicate [this empty database template](https://www.notion.com/367cd67cfe8f49bfaf0ac21305ebb9bf?v=bc79ca62b36e4c54b655ceed4ef06ebd).
 
+Your Notion integration will need access to the Notion database you have created. To provide access, follow the instructions found in Notion's [Integration guide](https://developers.notion.com/docs/create-a-notion-integration#step-2-share-a-database-with-your-integration).
+
 ### 3. Run code
 
 ```zsh


### PR DESCRIPTION
Small change: add instruction for giving integration access to database. An error is thrown if this step is not completed first.
Examples that require access to be given where instructions aren't already included: database-email-update, notion-github-sync