### PR TITLE
SDK Examples housekeeping tasks

### DIFF
--- a/examples/database-email-update/README.md
+++ b/examples/database-email-update/README.md
@@ -4,9 +4,9 @@
 
 ## About the Integration
 
-This Notion integration sends an email whenever the Status of a page in a database is updated. This sample was built using [this database template](https://www.notion.com/5b593126d3eb401db62c83cbe362d2d5?v=a44397b3675545f389a6f28282c402ae) and emails are sent using [SendGrid's API](https://sendgrid.com).
+This Notion integration sends an email whenever the Status of a page in a database is updated.
 
-## Running Locally
+This sample was built using [this database template](https://public-api-examples.notion.site/0def5dfb6d9b4cdaa907a0466834b9f4?v=aea75fc133e54b3382d12292291d9248) and emails are sent using [SendGrid's API](https://sendgrid.com).
 
 ### 1. Setup your local project
 
@@ -21,7 +21,26 @@ cd notion-sdk-js/examples/database-update-send-email
 npm install
 ```
 
-### 2. Set your environment variables in a `.env` file
+### 2. Setup a free account at [SendGrid](https://sendgrid.com)
+
+Sign up for a free account and follow the instructions to use the Email API.
+
+Choose the option for integrating with the Web API and follow instructions to
+get your API token.
+
+## Running Locally
+
+### 3. Setup your Notion workspace
+
+You can create your Notion API key [here](https://www.notion.com/my-integrations).
+
+To create a Notion database that will work with this example, duplicate [this database template](https://public-api-examples.notion.site/0def5dfb6d9b4cdaa907a0466834b9f4?v=aea75fc133e54b3382d12292291d9248).
+
+Your Notion integration will need access to the Notion database you have created. To provide access, follow the instructions found in Notion's [Integration guide](https://developers.notion.com/docs/create-a-notion-integration#step-2-share-a-database-with-your-integration).
+
+### 4. Set your environment variables to a `.env` file
+
+Rename `example.env` to `.env` in this directory and add the following fields:
 
 ```zsh
 NOTION_KEY=<your-notion-api-key>
@@ -31,16 +50,8 @@ EMAIL_TO_FIELD=<email-recipients>
 EMAIL_FROM_FIELD=<email-from-field>
 ```
 
-You can create your Notion API key [here](https://www.notion.com/my-integrations).
-
-You can create your SendGrid API key [here](https://signup.sendgrid.com).
-
-To create a Notion database that will work with this example, duplicate [this template](https://www.notion.com/5b593126d3eb401db62c83cbe362d2d5?v=a44397b3675545f389a6f28282c402ae).
-
-Your Notion integration will need access to the Notion database you have created. To provide access, follow the instructions found in Notion's [Integration guide](https://developers.notion.com/docs/create-a-notion-integration#step-2-share-a-database-with-your-integration).
-
-### 3. Run code
+### 5. Run code
 
 ```zsh
-node index.js
+npm run ts-run
 ```

--- a/examples/database-email-update/example.env
+++ b/examples/database-email-update/example.env
@@ -1,0 +1,5 @@
+NOTION_KEY=<your-notion-api-key>
+SENDGRID_KEY=<your-sendgrid-api-key>
+NOTION_DATABASE_ID=<your-notion-database-id>
+EMAIL_TO_FIELD=<email-recipients>
+EMAIL_FROM_FIELD=<email-from-field>

--- a/examples/database-email-update/package.json
+++ b/examples/database-email-update/package.json
@@ -8,12 +8,13 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": ""
+    "ts-run": "node --loader ts-node/esm index.ts"
   },
   "dependencies": {
-    "@notionhq/client": "^2.1.1",
+    "@notionhq/client": "file:../../",
     "@sendgrid/mail": "^7.7.0",
-    "dotenv": "^16.0.1"
+    "dotenv": "^16.0.1",
+    "ts-node": "^10.8.2"
   },
   "author": "Aman Gupta",
   "license": "MIT"

--- a/examples/database-email-update/tsconfig.json
+++ b/examples/database-email-update/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "sourceMap": false,
+
+    "target": "ESNext",
+    "module": "commonjs",
+
+    "moduleResolution": "Node",
+
+    "allowSyntheticDefaultImports": true,
+
+    "useDefineForClassFields": false,
+
+    "strict": false,
+    "suppressImplicitAnyIndexErrors": true,
+
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true,
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/generate-random-data/README.md
+++ b/examples/generate-random-data/README.md
@@ -1,9 +1,8 @@
-# API Example
+# Sample Integration: Generate Random Data with Notion API
 
 ## About the Integration
 
 This integration finds the first database which your bot has access to, and creates correctly typed random rows of data.
-It is designed to show and exercise the full types of the Notion API and the typescript bindings.
 
 ## Running Locally
 
@@ -20,17 +19,23 @@ cd notion-sdk-js/examples/generate-random-data
 npm install
 ```
 
-### 2. Set your environment variables in a `.env` file
-
-```zsh
-NOTION_KEY=<your-notion-api-key>
-```
+### 2. Setup your Notion workspace
 
 You can create your Notion API key [here](https://www.notion.com/my-integrations).
 
-To create a Notion database that will work with this example, duplicate [this empty database template](https://www.notion.com/367cd67cfe8f49bfaf0ac21305ebb9bf?v=bc79ca62b36e4c54b655ceed4ef06ebd).
+To create a Notion database that will work with this example, duplicate [this database template](https://public-api-examples.notion.site/f3e098475baa45878759ed8d04ea79af).
 
-### 3. Run code
+Your Notion integration will need access to the Notion database you have created. To provide access, follow the instructions found in Notion's [Integration guide](https://developers.notion.com/docs/create-a-notion-integration#step-2-share-a-database-with-your-integration).
+
+### 3. Set your environment variables to a `.env` file
+
+Rename `example.env` to `.env` in this directory and add your API key.
+
+```zsh
+NOTION_KEY=<api-key-you-created-in-the-previous-step>
+```
+
+### 4. Run code
 
 ```zsh
 npm run ts-run

--- a/examples/generate-random-data/example.env
+++ b/examples/generate-random-data/example.env
@@ -1,0 +1,1 @@
+NOTION_KEY=notion-api-key

--- a/examples/generate-random-data/package.json
+++ b/examples/generate-random-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generate-random-data",
-  "version": "1.0.0",
-  "description": "**TODO**",
+  "version": "1.0.1",
+  "description": "Generate random data in a Notion Database.",
   "main": "index.js",
   "scripts": {
     "ts-run": "node --loader ts-node/esm index.ts"

--- a/examples/notion-github-sync/package.json
+++ b/examples/notion-github-sync/package.json
@@ -13,7 +13,7 @@
   "author": "Aman Gupta",
   "license": "MIT",
   "dependencies": {
-    "@notionhq/client": "^2.1.1",
+    "@notionhq/client": "file:../../",
     "dotenv": "^16.0.1",
     "lodash": "^4.17.21",
     "octokit": "^2.0.3"

--- a/examples/notion-task-github-pr-sync/package.json
+++ b/examples/notion-task-github-pr-sync/package.json
@@ -13,7 +13,7 @@
   "author": "Sid Verma",
   "license": "MIT",
   "dependencies": {
-    "@notionhq/client": "^2.1.1",
+    "@notionhq/client": "file:../../",
     "dotenv": "^16.0.1",
     "lodash": "^4.17.21",
     "octokit": "^2.0.3"


### PR DESCRIPTION
Couple of housekeeping items:
- Update the SDK version in all example projects
- Cleaned up some of the example instructions to keep better consistency and easy of setup
- Migrated email sending example to Typescript 🥳 
- Started migrating templates to a single workspace to make updates easier for the team
- Fixed a bug in the random data example by adding a `rich_text` property to the template database.
- Started adding `example.env` files which users can rename easily to get the expected environment variables.