### PR TITLE
Fix bug for encoding filter_properties query parameter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint": "^7.24.0",
     "jest": "^28.1.2",
     "markdown-link-check": "^3.8.7",
-    "prettier": "^2.3.0",
+    "prettier": "^2.8.8",
     "ts-jest": "^28.0.5",
     "typescript": "^4.8.4"
   }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -155,7 +155,9 @@ export default class Client {
       for (const [key, value] of Object.entries(query)) {
         if (value !== undefined) {
           if (Array.isArray(value)) {
-            value.forEach(val => url.searchParams.append(key, String(val)))
+            value.forEach(val =>
+              url.searchParams.append(key, decodeURIComponent(val))
+            )
           } else {
             url.searchParams.append(key, String(value))
           }


### PR DESCRIPTION
Problem: `filter_properties` is a query parameter, which gets URI encoded when a request is made with the JS SDK. A bug report came in that when querying for a specific property in the [Query Database endpoint](https://developers.notion.com/reference/post-database-query), an error was occurring stating that the collection schema was invalid.

When you retrieve a database, the response already includes URI-encoded IDs for properties. This problem occurred because our JS SDK was further encoding the ID. For example:
- an ID `U:C<` was returned in the `notion.databases.retrieve()` call as `U%3AC%3C` (in the JS SDK)
- `U%3AC%3C` is passed to `notion.databases.query()` (the JS SDK) which was getting encoded once again to `U%253AC%253C`
- The Notion server looked for `U%253AC%253C` but couldn't find it & returned an error.

This PR fixes the JS SDK to not further encode an already encoded `filter_properties` query param ID. In this PR, we take the approach of decoding, passing the URL to `fetch`, so that `fetch` can encode subsequently. This complements Notion API's handling as well, so that a developer can copy/paste or include a property ID directly in a URL.

Note: this is isolated to endpoints that have query parameters with array types (currently, this is only `filter_properties`). Other query parameters, like `page_size` for [retrieving a page property item](https://developers.notion.com/reference/retrieve-a-page-property) are not impacted (I tested retrieve page property item with this change ✅ )