### PR TITLE
"parse-text-from-any-block-type" example bug fixed (not printing ordinary "rich_text" blocks)

### DIFF
--- a/examples/parse-text-from-any-block-type/index.js
+++ b/examples/parse-text-from-any-block-type/index.js
@@ -97,6 +97,9 @@ const getTextFromBlock = block => {
         // Does not include text from ToC; just the color
         text = "ToC color: " + block.table_of_contents.color
         break
+      case "rich_text": 
+        text = getPlainTextFromRichText(block.rich_text)
+        break;
       case "breadcrumb":
       case "column_list":
       case "divider":


### PR DESCRIPTION
The current version doesn't support a general `rich_text` case, for the following block:

```
{
  type: 'rich_text',
  rich_text: [
    {
      type: 'text',
      text: [Object],
      annotations: [Object],
      plain_text: 'plain!',
      href: null
    }
  ]
}
```

The first if condition:

```
if (block[block.type].rich_text) {
        // This will be an empty string if it's an empty line.
        text = getPlainTextFromRichText(block[block.type].rich_text)
    }
```

doesn't cover it, as it resolves to `block.rich_text.rich_text`.