### PR TITLE
feat: Log the response body when the request succeeds with LogLevel.DEBUG

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -220,6 +220,7 @@ export default class Client {
 
       const responseJson: ResponseBody = JSON.parse(responseText)
       this.log(LogLevel.INFO, `request success`, { method, path })
+      this.log(LogLevel.DEBUG, `succeed response body`, { body: responseText })
       return responseJson
     } catch (error: unknown) {
       if (!isNotionClientError(error)) {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -220,7 +220,7 @@ export default class Client {
 
       const responseJson: ResponseBody = JSON.parse(responseText)
       this.log(LogLevel.INFO, `request success`, { method, path })
-      this.log(LogLevel.DEBUG, `succeed response body`, { body: responseText })
+      this.log(LogLevel.DEBUG, `succeeded response body`, { body: responseText })
       return responseJson
     } catch (error: unknown) {
       if (!isNotionClientError(error)) {


### PR DESCRIPTION
## Issue

The README mentions that the response body will be logged on the DEBUG level, but the actual code currently supports logging only in error response cases. See following excerpt from the [README.md](https://github.com/makenotion/notion-sdk-js#logging)

> If you're debugging an application, and would like the client to log response bodies, set the logLevel option to LogLevel.DEBUG.

## Implementation

Added a log method for success response cases.

> [!NOTE]
> 
> This produces a non-pretty JSON string to prevent unintended creation of strings on non-DEBUG levels.

## Example

![image](https://github.com/makenotion/notion-sdk-js/assets/97666463/2c78bcda-0cd4-4d5a-ada7-af1a6689a639)
