### PR TITLE
fix: add missing `request_id` type to `OauthTokenResponse`

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -11166,6 +11166,7 @@ export type OauthTokenResponse = {
       }
     | { type: "workspace"; workspace: true }
   duplicated_template_id: string | null
+  request_id: string
 }
 
 export const oauthToken = {


### PR DESCRIPTION
This pull request addresses the addition of a missing `request_id` type in the `OauthTokenResponse` TypeScript definition

## Changes Made
Added TypeScript type definition for `request_id` in the `OauthTokenResponse`

## Example Oauth Response

```
{
  "access_token": ...,
  "token_type": ...,
  "bot_id": ...,
  "workspace_name": "Mohammed Esafi",
  "workspace_icon": null,
  "workspace_id": ...,
  "owner": ...,
  "duplicated_template_id": ...,
  "request_id": "ae17caab-bad9-424f-98c7-e00daa2a1317"
}
```

