### PR TITLE
Move node-fetch types to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "build/src/**"
   ],
   "dependencies": {
-    "@types/node-fetch": "^2.5.10",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@types/jest": "^28.1.4",
+    "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "cspell": "^5.4.1",


### PR DESCRIPTION
Currently `@types/node-fetch` is included in `dependencies` which is bloating production builds with types:

https://github.com/makenotion/notion-sdk-js/blob/b66c67dbdadc7c72312869311ea735063db758b1/package.json#L43

Types aren't used in production, so this makes no functional difference, this PR just moves it in to `devDependencies` like the other `@types/...` dependencies.