### PR TITLE
Update README.md with correct `cd` command

### DIFF
--- a/examples/intro-to-notion-api/README.md
+++ b/examples/intro-to-notion-api/README.md
@@ -35,13 +35,13 @@ To use this example on your machine, clone the repo and move into your local cop
 
 ```zsh
 git clone https://github.com/makenotion/notion-sdk-js.git
-cd /notion-sdk-js
+cd notion-sdk-js
 ```
 
 Next, move into this example in the `/examples` directory, and install its dependencies:
 
 ```zsh
-cd /examples/intro-to-notion-api
+cd examples/intro-to-notion-api
 npm install
 ```
 


### PR DESCRIPTION
**nitpick:** incorrect and / or misleading `cd` command

**explanation:** The slash `/` at the beginning of the path points to the root of the filesystem, so `cd /notion-sdk-js` tries to change to a directory that is directly under the root directory. That is not where the cloned repo would be based on the first `git clone` command

**reason for change:** could confuse some beginners 🤷‍♀️