### PR TITLE
Use isomorphic fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x, 16.x]
+        node-version: [18.x, 19.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testRegex: "\\.test\\.ts$",
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "homepage": "https://developers.notion.com/docs/getting-started",
   "bugs": {
@@ -39,12 +39,9 @@
     "build/package.json",
     "build/src/**"
   ],
-  "dependencies": {
-    "@types/node-fetch": "^2.5.10",
-    "node-fetch": "^2.6.1"
-  },
   "devDependencies": {
     "@types/jest": "^28.1.4",
+    "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "cspell": "^5.4.1",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -83,7 +83,6 @@ import {
   type OauthRevokeParameters,
   oauthRevoke,
 } from "./api-endpoints"
-import nodeFetch from "node-fetch"
 import {
   version as PACKAGE_VERSION,
   name as PACKAGE_NAME,
@@ -140,7 +139,7 @@ export default class Client {
     this.#prefixUrl = `${options?.baseUrl ?? "https://api.notion.com"}/v1/`
     this.#timeoutMs = options?.timeoutMs ?? 60_000
     this.#notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
-    this.#fetch = options?.fetch ?? nodeFetch
+    this.#fetch = options?.fetch ?? fetch
     this.#agent = options?.agent
     this.#userAgent = `notionhq-client/${PACKAGE_VERSION}`
   }


### PR DESCRIPTION
Since `fetch` is stable in the current LTS version of Node, I don't see any good reason for using node-fetch or any other solution than the web standard.