### PR TITLE
Export AnnotationResponse type (#507)

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -739,7 +739,7 @@ type VerificationPropertyResponse = {
     | null
 }
 
-type AnnotationResponse = {
+export type AnnotationResponse = {
   bold: boolean
   italic: boolean
   strikethrough: boolean


### PR DESCRIPTION
As i promised in this issue: https://github.com/makenotion/notion-sdk-js/issues/507.

The pull request to add the `export` keyword to the `AnnotationResponse` type. Now, the type is available to import via `import { AnnotationResponse } from '@notionhq/client/build/src/api-endpoints'`