### PR TITLE
fix: export item response types from src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+export type {
+  EquationRichTextItemResponse,
+  MentionRichTextItemResponse,
+  RichTextItemResponse,
+  TextRichTextItemResponse,
+} from "./api-endpoints"
 export { default as Client } from "./Client"
 export { LogLevel, Logger } from "./logging"
 export {


### PR DESCRIPTION
Sibling to #507 / #519: it looks like of odd that we're importing types from the long `@notionhq/client/build/src/api-endpoints.js`. This should let consumers import from the package itself:

```ts
import type { RichTextItemResponse } from "@notionhq/client";
```