### PR TITLE
add `default_background` option to `AnnotationResponse` type

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -756,6 +756,7 @@ type AnnotationResponse = {
     | "purple"
     | "pink"
     | "red"
+    | "default_background"
     | "gray_background"
     | "brown_background"
     | "orange_background"


### PR DESCRIPTION
**Description**  
This PR adds the `default_background` variant to the `color` property in RichText's Annotation type.

**Related Issue**  
- Fixes #536 