### PR TITLE
Proposal: Add ability to quickly run starter project on Val Town

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![npm version](https://badge.fury.io/js/%40notionhq%2Fclient.svg)](https://www.npmjs.com/package/@notionhq/client)
 
 ## Installation
+[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/charmaine/NotionJsSDK)
 
 ```
 npm install @notionhq/client


### PR DESCRIPTION
Hey there! 

I’d love to propose adding a [Val Town](https://www.val.town/) badge to your docs so new users can spin up the Notion SDK for JavaScript in just one click.

I work at Val Town, and it would truly mean a lot to us to have a place in Notion’s docs or open-source repos. We’re totally open to any tweaks you’d like us to make!

## Proposed badge in README:
[![Open Val Town Template](https://stevekrouse-badge.web.val.run/?3)](https://www.val.town/v/charmaine/NotionJsSDK)

## In action:
![Clipboard-20250204-190530-793](https://github.com/user-attachments/assets/3de8a284-5f98-4645-be5a-f78e9830c4f3)

## Why this could be helpful:
1.  Gives users instant access to a working example, so they can see everything in context right away.
2.  Lets them fork and customize the example in a single click.
3.  Helps avoid local environment headaches (like node/npm issues) so users can focus on your SDK instead.

We recently did this with [Steel's Cookbook](https://github.com/steel-dev/steel-cookbook/blob/main/examples/steel-puppeteer-starter/README.md) and they were [super excited about it](https://x.com/hussufo/status/1884332147122766090), so we thought it'd be awesome to bring the same experience to Notion. We're all [huge fans of Notion](https://www.val.town/examples/apis/Notion) here!

We’re happy to help maintain this starter on Val Town as your SDK evolves, or you’re welcome to fork it so you have full control.

This PR should be good to go as-is, but we’d love to hear your thoughts! 😊