### PR TITLE
Add missing optional fields to LinkMentionResponse

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -778,7 +778,19 @@ export type TextRichTextItemResponse = {
 
 type LinkPreviewMentionResponse = { url: TextRequest }
 
-type LinkMentionResponse = { href: string }
+type LinkMentionResponse = {
+  href: string
+  title?: string
+  description?: string
+  link_author?: string
+  link_provider?: string
+  thumbnail_url?: string
+  icon_url?: string
+  iframe_url?: string
+  height?: number
+  padding?: number
+  padding_top?: number
+}
 
 type TemplateMentionDateTemplateMentionResponse = {
   type: "template_mention_date"


### PR DESCRIPTION
This PR updates the SDK `src/api-endpoints.ts` with Notion's latest Public API spec.

Changes:
- Add several missing fields to `LinkMentionResponse`, all of which are optional:
  - `title`, `description`, `link_author`, `link_provider`, `thumbnail_url`, `icon_url`, `iframe_url`, `height`, `padding`, `padding_top`