### PR TITLE
docs: fix incorrect example path in README

### DIFF
--- a/examples/database-email-update/README.md
+++ b/examples/database-email-update/README.md
@@ -15,7 +15,7 @@ This sample was built using [this database template](https://public-api-examples
 git clone https://github.com/makenotion/notion-sdk-js.git
 
 # Switch into this project
-cd notion-sdk-js/examples/database-update-send-email
+cd notion-sdk-js/examples/database-email-update
 
 # Install the dependencies
 npm install


### PR DESCRIPTION
This PR updates the path to the correct one. 
There is no file named 'database-update-send-email' in the examples directory.

Changes: 
- Fixed the incorrect example path in [README](https://github.com/makenotion/notion-sdk-js/tree/main/examples/database-email-update)  