### PR TITLE
Sync OpenAPI schema as of 2025-04-08 to `src/api-endpoints.ts`

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -6344,6 +6344,14 @@ type RichTextItemRequest =
       }
     }
 
+type InternalFileRequest = { url: string; expiry_time?: string }
+
+type ExternalFileRequest = { url: TextRequest }
+
+type InternalOrExternalFileWithNameRequest =
+  | { file: InternalFileRequest; name: StringRequest; type?: "file" }
+  | { external: ExternalFileRequest; name: StringRequest; type?: "external" }
+
 export type BlockObjectRequestWithoutChildren =
   | {
       embed: { url: string; caption?: Array<RichTextItemRequest> }
@@ -6357,7 +6365,7 @@ export type BlockObjectRequestWithoutChildren =
     }
   | {
       image: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6366,7 +6374,7 @@ export type BlockObjectRequestWithoutChildren =
     }
   | {
       video: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6375,7 +6383,7 @@ export type BlockObjectRequestWithoutChildren =
     }
   | {
       pdf: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6384,7 +6392,7 @@ export type BlockObjectRequestWithoutChildren =
     }
   | {
       file: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
         name?: StringRequest
@@ -6394,7 +6402,7 @@ export type BlockObjectRequestWithoutChildren =
     }
   | {
       audio: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6508,7 +6516,7 @@ export type BlockObjectRequestWithoutChildren =
         rich_text: Array<RichTextItemRequest>
         icon?:
           | { emoji: EmojiRequest; type?: "emoji" }
-          | { external: { url: TextRequest }; type?: "external" }
+          | { external: ExternalFileRequest; type?: "external" }
           | {
               custom_emoji: { id: IdRequest; name?: string; url?: string }
               type?: "custom_emoji"
@@ -6539,7 +6547,7 @@ export type BlockObjectRequest =
     }
   | {
       image: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6548,7 +6556,7 @@ export type BlockObjectRequest =
     }
   | {
       video: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6557,7 +6565,7 @@ export type BlockObjectRequest =
     }
   | {
       pdf: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6566,7 +6574,7 @@ export type BlockObjectRequest =
     }
   | {
       file: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
         name?: StringRequest
@@ -6576,7 +6584,7 @@ export type BlockObjectRequest =
     }
   | {
       audio: {
-        external: { url: TextRequest }
+        external: ExternalFileRequest
         type?: "external"
         caption?: Array<RichTextItemRequest>
       }
@@ -6647,7 +6655,7 @@ export type BlockObjectRequest =
                 }
               | {
                   image: {
-                    external: { url: TextRequest }
+                    external: ExternalFileRequest
                     type?: "external"
                     caption?: Array<RichTextItemRequest>
                   }
@@ -6656,7 +6664,7 @@ export type BlockObjectRequest =
                 }
               | {
                   video: {
-                    external: { url: TextRequest }
+                    external: ExternalFileRequest
                     type?: "external"
                     caption?: Array<RichTextItemRequest>
                   }
@@ -6665,7 +6673,7 @@ export type BlockObjectRequest =
                 }
               | {
                   pdf: {
-                    external: { url: TextRequest }
+                    external: ExternalFileRequest
                     type?: "external"
                     caption?: Array<RichTextItemRequest>
                   }
@@ -6674,7 +6682,7 @@ export type BlockObjectRequest =
                 }
               | {
                   file: {
-                    external: { url: TextRequest }
+                    external: ExternalFileRequest
                     type?: "external"
                     caption?: Array<RichTextItemRequest>
                     name?: StringRequest
@@ -6684,7 +6692,7 @@ export type BlockObjectRequest =
                 }
               | {
                   audio: {
-                    external: { url: TextRequest }
+                    external: ExternalFileRequest
                     type?: "external"
                     caption?: Array<RichTextItemRequest>
                   }
@@ -6843,7 +6851,7 @@ export type BlockObjectRequest =
                     children?: Array<BlockObjectRequestWithoutChildren>
                     icon?:
                       | { emoji: EmojiRequest; type?: "emoji" }
-                      | { external: { url: TextRequest }; type?: "external" }
+                      | { external: ExternalFileRequest; type?: "external" }
                       | {
                           custom_emoji: {
                             id: IdRequest
@@ -6891,7 +6899,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -6900,7 +6908,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -6909,7 +6917,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -6918,7 +6926,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -6928,7 +6936,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7083,7 +7091,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -7127,7 +7135,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7136,7 +7144,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7145,7 +7153,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7154,7 +7162,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -7164,7 +7172,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7319,7 +7327,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -7363,7 +7371,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7372,7 +7380,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7381,7 +7389,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7390,7 +7398,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -7400,7 +7408,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7555,7 +7563,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -7599,7 +7607,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7608,7 +7616,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7617,7 +7625,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7626,7 +7634,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -7636,7 +7644,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7791,7 +7799,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -7834,7 +7842,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7843,7 +7851,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7852,7 +7860,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -7861,7 +7869,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -7871,7 +7879,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8026,7 +8034,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -8069,7 +8077,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8078,7 +8086,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8087,7 +8095,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8096,7 +8104,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -8106,7 +8114,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8261,7 +8269,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -8304,7 +8312,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8313,7 +8321,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8322,7 +8330,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8331,7 +8339,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -8341,7 +8349,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8496,7 +8504,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -8539,7 +8547,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8548,7 +8556,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8557,7 +8565,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8566,7 +8574,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -8576,7 +8584,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8731,7 +8739,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -8774,7 +8782,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8783,7 +8791,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8792,7 +8800,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8801,7 +8809,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -8811,7 +8819,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -8966,7 +8974,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -9010,7 +9018,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9019,7 +9027,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9028,7 +9036,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9037,7 +9045,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -9047,7 +9055,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9202,7 +9210,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -9244,7 +9252,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9253,7 +9261,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9262,7 +9270,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9271,7 +9279,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -9281,7 +9289,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9436,7 +9444,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -9479,7 +9487,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9488,7 +9496,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9497,7 +9505,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9506,7 +9514,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -9516,7 +9524,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9671,7 +9679,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -9695,7 +9703,7 @@ export type BlockObjectRequest =
         >
         icon?:
           | { emoji: EmojiRequest; type?: "emoji" }
-          | { external: { url: TextRequest }; type?: "external" }
+          | { external: ExternalFileRequest; type?: "external" }
           | {
               custom_emoji: { id: IdRequest; name?: string; url?: string }
               type?: "custom_emoji"
@@ -9720,7 +9728,7 @@ export type BlockObjectRequest =
             }
           | {
               image: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9729,7 +9737,7 @@ export type BlockObjectRequest =
             }
           | {
               video: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9738,7 +9746,7 @@ export type BlockObjectRequest =
             }
           | {
               pdf: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9747,7 +9755,7 @@ export type BlockObjectRequest =
             }
           | {
               file: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
                 name?: StringRequest
@@ -9757,7 +9765,7 @@ export type BlockObjectRequest =
             }
           | {
               audio: {
-                external: { url: TextRequest }
+                external: ExternalFileRequest
                 type?: "external"
                 caption?: Array<RichTextItemRequest>
               }
@@ -9912,7 +9920,7 @@ export type BlockObjectRequest =
                 children?: Array<BlockObjectRequestWithoutChildren>
                 icon?:
                   | { emoji: EmojiRequest; type?: "emoji" }
-                  | { external: { url: TextRequest }; type?: "external" }
+                  | { external: ExternalFileRequest; type?: "external" }
                   | {
                       custom_emoji: {
                         id: IdRequest
@@ -10225,18 +10233,7 @@ type CreatePageBodyParameters = {
         | { checkbox: boolean; type?: "checkbox" }
         | { relation: Array<{ id: IdRequest }>; type?: "relation" }
         | {
-            files: Array<
-              | {
-                  file: { url: string; expiry_time?: string }
-                  name: StringRequest
-                  type?: "file"
-                }
-              | {
-                  external: { url: TextRequest }
-                  name: StringRequest
-                  type?: "external"
-                }
-            >
+            files: Array<InternalOrExternalFileWithNameRequest>
             type?: "files"
           }
         | {
@@ -10340,18 +10337,7 @@ type CreatePageBodyParameters = {
         | null
         | boolean
         | Array<{ id: IdRequest }>
-        | Array<
-            | {
-                file: { url: string; expiry_time?: string }
-                name: StringRequest
-                type?: "file"
-              }
-            | {
-                external: { url: TextRequest }
-                name: StringRequest
-                type?: "external"
-              }
-          >
+        | Array<InternalOrExternalFileWithNameRequest>
         | {
             id: StringRequest
             name?: StringRequest
@@ -10370,14 +10356,14 @@ type CreatePageBodyParameters = {
   icon?:
     | { emoji: EmojiRequest; type?: "emoji" }
     | null
-    | { external: { url: TextRequest }; type?: "external" }
+    | { external: ExternalFileRequest; type?: "external" }
     | null
     | {
         custom_emoji: { id: IdRequest; name?: string; url?: string }
         type?: "custom_emoji"
       }
     | null
-  cover?: { external: { url: TextRequest }; type?: "external" } | null
+  cover?: { external: ExternalFileRequest; type?: "external" } | null
   content?: Array<BlockObjectRequest>
   children?: Array<BlockObjectRequest>
 }
@@ -10508,18 +10494,7 @@ type UpdatePageBodyParameters = {
         | { checkbox: boolean; type?: "checkbox" }
         | { relation: Array<{ id: IdRequest }>; type?: "relation" }
         | {
-            files: Array<
-              | {
-                  file: { url: string; expiry_time?: string }
-                  name: StringRequest
-                  type?: "file"
-                }
-              | {
-                  external: { url: TextRequest }
-                  name: StringRequest
-                  type?: "external"
-                }
-            >
+            files: Array<InternalOrExternalFileWithNameRequest>
             type?: "files"
           }
         | {
@@ -10623,18 +10598,7 @@ type UpdatePageBodyParameters = {
         | null
         | boolean
         | Array<{ id: IdRequest }>
-        | Array<
-            | {
-                file: { url: string; expiry_time?: string }
-                name: StringRequest
-                type?: "file"
-              }
-            | {
-                external: { url: TextRequest }
-                name: StringRequest
-                type?: "external"
-              }
-          >
+        | Array<InternalOrExternalFileWithNameRequest>
         | {
             id: StringRequest
             name?: StringRequest
@@ -10653,14 +10617,14 @@ type UpdatePageBodyParameters = {
   icon?:
     | { emoji: EmojiRequest; type?: "emoji" }
     | null
-    | { external: { url: TextRequest }; type?: "external" }
+    | { external: ExternalFileRequest; type?: "external" }
     | null
     | {
         custom_emoji: { id: IdRequest; name?: string; url?: string }
         type?: "custom_emoji"
       }
     | null
-  cover?: { external: { url: TextRequest }; type?: "external" } | null
+  cover?: { external: ExternalFileRequest; type?: "external" } | null
   archived?: boolean
   in_trash?: boolean
 }
@@ -10740,7 +10704,7 @@ type UpdateBlockBodyParameters =
   | {
       image: {
         caption?: Array<RichTextItemRequest>
-        external?: { url: TextRequest }
+        external?: ExternalFileRequest
       }
       type?: "image"
       archived?: boolean
@@ -10749,7 +10713,7 @@ type UpdateBlockBodyParameters =
   | {
       video: {
         caption?: Array<RichTextItemRequest>
-        external?: { url: TextRequest }
+        external?: ExternalFileRequest
       }
       type?: "video"
       archived?: boolean
@@ -10758,7 +10722,7 @@ type UpdateBlockBodyParameters =
   | {
       pdf: {
         caption?: Array<RichTextItemRequest>
-        external?: { url: TextRequest }
+        external?: ExternalFileRequest
       }
       type?: "pdf"
       archived?: boolean
@@ -10767,7 +10731,7 @@ type UpdateBlockBodyParameters =
   | {
       file: {
         caption?: Array<RichTextItemRequest>
-        external?: { url: TextRequest }
+        external?: ExternalFileRequest
         name?: StringRequest
       }
       type?: "file"
@@ -10777,7 +10741,7 @@ type UpdateBlockBodyParameters =
   | {
       audio: {
         caption?: Array<RichTextItemRequest>
-        external?: { url: TextRequest }
+        external?: ExternalFileRequest
       }
       type?: "audio"
       archived?: boolean
@@ -10919,7 +10883,7 @@ type UpdateBlockBodyParameters =
         rich_text?: Array<RichTextItemRequest>
         icon?:
           | { emoji: EmojiRequest; type?: "emoji" }
-          | { external: { url: TextRequest }; type?: "external" }
+          | { external: ExternalFileRequest; type?: "external" }
           | {
               custom_emoji: { id: IdRequest; name?: string; url?: string }
               type?: "custom_emoji"
@@ -11098,14 +11062,14 @@ type UpdateDatabaseBodyParameters = {
   icon?:
     | { emoji: EmojiRequest; type?: "emoji" }
     | null
-    | { external: { url: TextRequest }; type?: "external" }
+    | { external: ExternalFileRequest; type?: "external" }
     | null
     | {
         custom_emoji: { id: IdRequest; name?: string; url?: string }
         type?: "custom_emoji"
       }
     | null
-  cover?: { external: { url: TextRequest }; type?: "external" } | null
+  cover?: { external: ExternalFileRequest; type?: "external" } | null
   properties?: Record<
     string,
     | {
@@ -11611,14 +11575,14 @@ type CreateDatabaseBodyParameters = {
   icon?:
     | { emoji: EmojiRequest; type?: "emoji" }
     | null
-    | { external: { url: TextRequest }; type?: "external" }
+    | { external: ExternalFileRequest; type?: "external" }
     | null
     | {
         custom_emoji: { id: IdRequest; name?: string; url?: string }
         type?: "custom_emoji"
       }
     | null
-  cover?: { external: { url: TextRequest }; type?: "external" } | null
+  cover?: { external: ExternalFileRequest; type?: "external" } | null
   title?: Array<RichTextItemRequest>
   description?: Array<RichTextItemRequest>
   is_inline?: boolean
@@ -11684,6 +11648,10 @@ export const search = {
 type CreateCommentBodyParameters =
   | {
       parent: { page_id: IdRequest; type?: "page_id" }
+      rich_text: Array<RichTextItemRequest>
+    }
+  | {
+      parent: { block_id: IdRequest; type?: "block_id" }
       rich_text: Array<RichTextItemRequest>
     }
   | { discussion_id: IdRequest; rich_text: Array<RichTextItemRequest> }


### PR DESCRIPTION
Sync Notion's public API specification as of today (2025-04-08) into `src/api-endpoints.ts`.

**Summary of changes**:
- Refactor common parameter shapes into new types: `InternalFileRequest`, `ExternalFileRequest`, and `InternalOrExternalFileWithNameRequest`
- Support commenting on a non-page block in the Create Comment API by accepting a parent type of `block_id`