### PR TITLE
Bump major version to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Ran `npm version major`

This new version tag will include the following changes: https://github.com/makenotion/notion-sdk-js/compare/650d23bd94c1cd9a4179fcbea25be617e2f5a7e5...d7694613258a01a227ade06a841fcf9207edb801