### PR TITLE
Add file upload API example and fix `Blob` send logic

### DIFF
--- a/examples/intro-to-notion-api/.prettierrc
+++ b/examples/intro-to-notion-api/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "arrowParens": "avoid",
+  "tabWidth": 2,
+  "semi": false,
+  "trailingComma": "es5",
+  "endOfLine": "lf",
+  "singleQuote": false
+}

--- a/examples/intro-to-notion-api/README.md
+++ b/examples/intro-to-notion-api/README.md
@@ -26,7 +26,7 @@ In case you are looking for example code for a specific task, the files are divi
 - `/intermediate/2-add-page-to-database.js`: Create a new database and add new pages to it.
 - `/intermediate/3-query-database.js`: Create a new database, add pages to it, and filter the database entries (pages).
 - `/intermediate/4-sort-database.js`: Create a new database, add pages to it, and filter/sort the database entries (pages).
-- `/intermediate/5-upload-file.js`: Upload an file to Notion and attach it to a page as an image block.
+- `/intermediate/5-upload-file.js`: Upload a file to Notion and attach it to a page as an image block.
 
 ## Running locally
 

--- a/examples/intro-to-notion-api/README.md
+++ b/examples/intro-to-notion-api/README.md
@@ -26,6 +26,7 @@ In case you are looking for example code for a specific task, the files are divi
 - `/intermediate/2-add-page-to-database.js`: Create a new database and add new pages to it.
 - `/intermediate/3-query-database.js`: Create a new database, add pages to it, and filter the database entries (pages).
 - `/intermediate/4-sort-database.js`: Create a new database, add pages to it, and filter/sort the database entries (pages).
+- `/intermediate/5-upload-file.js`: Upload an file to Notion and attach it to a page as an image block.
 
 ## Running locally
 
@@ -83,7 +84,7 @@ To run each individual example, use the `node` command with the file's path.
 For example:
 
 ```zsh
-node /basic/1-add-block.js
+node basic/1-add-block.js
 ```
 
 ---

--- a/examples/intro-to-notion-api/intermediate/5-upload-file.js
+++ b/examples/intro-to-notion-api/intermediate/5-upload-file.js
@@ -1,0 +1,80 @@
+import { Client } from "@notionhq/client"
+import { config } from "dotenv"
+import { openAsBlob } from "fs"
+import { basename, join } from "path"
+
+config()
+
+const pageId = process.env.NOTION_PAGE_ID
+const apiKey = process.env.NOTION_API_KEY
+
+const notion = new Client({ auth: apiKey })
+
+/*
+---------------------------------------------------------------------------
+*/
+
+/**
+ * Resources:
+ * - File upload guide: https://developers.notion.com/docs/uploading-small-files
+ * - Create file upload API: https://developers.notion.com/reference/create-a-file-upload
+ */
+
+async function createFileUpload() {
+  return await notion.fileUploads.create({
+    mode: "single_part",
+  })
+}
+
+async function sendFileUpload(fileUploadId, filePath) {
+  return await notion.fileUploads.send({
+    file_upload_id: fileUploadId,
+    file: {
+      filename: basename(filePath),
+      data: new Blob([await openAsBlob(filePath)], {
+        type: "image/png",
+      }),
+    },
+  })
+}
+
+async function appendBlockChildren(blockId, fileUploadId) {
+  return await notion.blocks.children.append({
+    block_id: blockId,
+    children: [
+      {
+        type: "image",
+        image: {
+          type: "file_upload",
+          file_upload: {
+            id: fileUploadId,
+          },
+        },
+      },
+    ],
+  })
+}
+
+async function main() {
+  let fileUpload = await createFileUpload()
+  console.log("Created file upload with ID:", fileUpload.id)
+
+  fileUpload = await sendFileUpload(
+    fileUpload.id,
+    join(process.argv[1], "..", "..", "assets", "page_id.png")
+  )
+  console.log(
+    "Uploaded page_id.png to file upload; status is now:",
+    fileUpload.status
+  )
+
+  const result = await appendBlockChildren(pageId, fileUpload.id)
+  console.log(
+    "Appended block children; new list of block children is:",
+    result.results.map(block => block.id)
+  )
+
+  console.log("Done! Image added to page:", pageId)
+}
+
+await main()

--- a/examples/intro-to-notion-api/package.json
+++ b/examples/intro-to-notion-api/package.json
@@ -20,5 +20,8 @@
   "dependencies": {
     "@notionhq/client": "file:../..",
     "dotenv": "^16.3.1"
+  },
+  "devDependencies": {
+    "prettier": "3.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/parser": "^5.39.0",
     "cspell": "^5.4.1",
     "eslint": "^7.24.0",
+    "formdata-node": "^6.0.3",
     "jest": "^28.1.2",
     "markdown-link-check": "^3.8.7",
     "prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@typescript-eslint/parser": "^5.39.0",
     "cspell": "^5.4.1",
     "eslint": "^7.24.0",
-    "formdata-node": "^6.0.3",
     "jest": "^28.1.2",
     "markdown-link-check": "^3.8.7",
     "prettier": "^2.8.8",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -103,6 +103,7 @@ import {
   name as PACKAGE_NAME,
 } from "../package.json"
 import type { SupportedFetch } from "./fetch-types"
+import type { Readable } from "stream"
 
 export interface ClientOptions {
   auth?: string
@@ -246,7 +247,7 @@ export default class Client {
         this.#fetch(url.toString(), {
           method: method.toUpperCase(),
           headers,
-          body: bodyAsJsonString ?? (formData as any),
+          body: bodyAsJsonString ?? (formData as unknown as Readable),
           agent: this.#agent,
         }),
         this.#timeoutMs

--- a/src/fetch-types.ts
+++ b/src/fetch-types.ts
@@ -6,7 +6,7 @@ import type {
   RequestInit as NodeFetchRequestInit,
   Response as NodeFetchResponse,
 } from "node-fetch"
-import { Readable } from "stream"
+import type { Readable } from "stream"
 
 // The `Supported` types should be kept up to date in order to exactly match what we use in the client. This ensures maximal compatibility with other `fetch` implementations.
 export type SupportedRequestInfo = string

--- a/src/fetch-types.ts
+++ b/src/fetch-types.ts
@@ -6,7 +6,7 @@ import type {
   RequestInit as NodeFetchRequestInit,
   Response as NodeFetchResponse,
 } from "node-fetch"
-import type FormData = require("form-data")
+import { Readable } from "stream"
 
 // The `Supported` types should be kept up to date in order to exactly match what we use in the client. This ensures maximal compatibility with other `fetch` implementations.
 export type SupportedRequestInfo = string
@@ -18,7 +18,7 @@ type _assertSupportedInfoIsSubtypeOfNodeFetch = Assert<
 
 export type SupportedRequestInit = {
   agent?: Agent
-  body?: string | FormData
+  body?: string | Readable
   headers?: Record<string, string>
   method?: string
 }

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -110,7 +110,8 @@ describe("Notion SDK Client", () => {
 
       expect(formData["part_number"]).toEqual("2")
 
-      assert(formData["file"] instanceof File)
+      assert(typeof formData["file"] === "object")
+      assert("size" in formData["file"])
       expect(formData["file"].size).toEqual(4)
     })
   })

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -1,3 +1,4 @@
+import assert = require("node:assert")
 import { Client } from "../src"
 
 describe("Notion SDK Client", () => {
@@ -104,20 +105,13 @@ describe("Notion SDK Client", () => {
       expect(firstCallParams?.headers).not.toContain("content-type")
       expect(firstCallParams?.headers).not.toContain("Content-Type")
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const body = { ...(firstCallParams?.body as any) }
-      const streams = body["_streams"]
+      const body = firstCallParams?.body as FormData
+      const formData = Object.fromEntries(body.entries())
 
-      expect(streams).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining(
-            'Content-Disposition: form-data; name="file"; filename="test.txt"'
-          ),
-          expect.stringContaining(
-            'Content-Disposition: form-data; name="part_number"'
-          ),
-        ])
-      )
+      expect(formData["part_number"]).toEqual("2")
+
+      assert(formData["file"] instanceof File)
+      expect(formData["file"].size).toEqual(4)
     })
   })
 })

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -1,4 +1,4 @@
-import assert = require("node:assert")
+import assert = require("assert")
 import { Client } from "../src"
 
 describe("Notion SDK Client", () => {


### PR DESCRIPTION
Follow-ups to #565:

- Fix the `FormData` parameter passing logic in `src/Client.ts` for the Send File Upload API
- Add `examples/intro-to-notion-api/intermediate/5-upload-file.js` example of using the File Upload API to upload and attach a file