### PR TITLE
Minor version bump: v3.0.1 → v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
This PR commits the result of `npm version minor`, bumping the `package.json` version of `@notionhq/client` from `3.0.1` to `3.1.0`. This includes the following PRs (mostly related to adding basic support for `fileUploads` APIs):
- https://github.com/makenotion/notion-sdk-js/pull/565
- https://github.com/makenotion/notion-sdk-js/pull/566