### PR TITLE
Updates node/nvm version required

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+lts/hydrogen

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ const blocks = await collectPaginatedAPI(notion.blocks.children.list, {
 
 This package supports the following minimum versions:
 
-- Runtime: `node >= 12`
+- Runtime: `node >= 18`
 - Type definitions (optional): `typescript >= 4.5`
 
 Earlier versions may still work, but we encourage people building new applications to upgrade to the current stable.


### PR DESCRIPTION
`nvm use` failed as package is asking for 18 and docs and .nvmrc wanted 12/14 respectively.