### PR TITLE
fix(types): Support browser fetch and remove node-fetch types

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   ],
   "devDependencies": {
     "@types/jest": "^28.1.4",
-    "@types/node-fetch": "^2.5.10",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "cspell": "^5.4.1",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -103,7 +103,6 @@ import {
   name as PACKAGE_NAME,
 } from "../package.json"
 import type { SupportedFetch } from "./fetch-types"
-import type { Readable } from "stream"
 
 export interface ClientOptions {
   auth?: string
@@ -247,7 +246,7 @@ export default class Client {
         this.#fetch(url.toString(), {
           method: method.toUpperCase(),
           headers,
-          body: bodyAsJsonString ?? (formData as unknown as Readable),
+          body: bodyAsJsonString ?? formData,
           agent: this.#agent,
         }),
         this.#timeoutMs

--- a/src/fetch-types.ts
+++ b/src/fetch-types.ts
@@ -1,31 +1,14 @@
 import type { Agent } from "http"
-import type { Assert } from "./type-utils"
-import type NodeFetchFn from "node-fetch"
-import type {
-  RequestInfo as NodeFetchRequestInfo,
-  RequestInit as NodeFetchRequestInit,
-  Response as NodeFetchResponse,
-} from "node-fetch"
-import type { Readable } from "stream"
 
 // The `Supported` types should be kept up to date in order to exactly match what we use in the client. This ensures maximal compatibility with other `fetch` implementations.
 export type SupportedRequestInfo = string
-// We can't assert against the browser or native Node fetch types without complicating the package structure (see #401), so perform a best effort against `node-fetch`, which we use by default.
-type _assertSupportedInfoIsSubtypeOfNodeFetch = Assert<
-  NodeFetchRequestInfo,
-  SupportedRequestInfo
->
 
 export type SupportedRequestInit = {
   agent?: Agent
-  body?: string | Readable
+  body?: string | FormData
   headers?: Record<string, string>
   method?: string
 }
-type _assertSupportedInitIsSubtypeOfNodeFetch = Assert<
-  NodeFetchRequestInit,
-  SupportedRequestInit
->
 
 export type SupportedResponse = {
   ok: boolean
@@ -33,16 +16,8 @@ export type SupportedResponse = {
   headers: unknown
   status: number
 }
-type _assertSupportedResponseIsSubtypeOfNodeFetch = Assert<
-  SupportedResponse,
-  NodeFetchResponse
->
 
 export type SupportedFetch = (
   url: SupportedRequestInfo,
   init?: SupportedRequestInit
 ) => Promise<SupportedResponse>
-type _assertSupportedFetchIsSubtypeOfNodeFetch = Assert<
-  SupportedFetch,
-  typeof NodeFetchFn
->


### PR DESCRIPTION
## Issue

#565 and #566 introduced changes to the `SupportedFetch` type that make it incompatible with the browser `fetch` function. Specifically, `SupportedRequestInit['body']` was [changed](https://github.com/makenotion/notion-sdk-js/compare/v3.0.1...v3.1.0#diff-a570c00994d666ae078f11f697662d819f448fd464a194410559e690c374a066L20-R21) to use the `Readable` type from the `node:stream` module, and this is incompatible with the type of `body` in the DOM types library. This causes a type error when trying to pass the browser's `fetch` function for the `fetch` parameter of the `Client` constructor.

A minimal reproduction is available in https://github.com/dvanoni/notion-supportedfetch-types.

## Fix

This PR changes `SupportedRequestInit['body']` to use the global `FormData` type rather than `Readable`. This works for both browser and Node environments because the [type definition in `@types/node`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8df9f9d10b77323c7104829adcd6a191c9cce28d/types/node/globals.d.ts#L342-L347) uses the `FormData` type from `globalThis` if available (i.e. in a browser environment), and otherwise it uses `undici-types` (i.e. in a Node environment).

Additionally, since `node-fetch` was removed in #506, this PR also removes the assertions against `node-fetch` types and removes `@types/node-fetch` as a dependency.