### PR TITLE
Remove legacy (<=2021) v1 API shape for page properties

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -7161,166 +7161,100 @@ type CreatePageBodyParameters = {
   parent:
     | { page_id: IdRequest; type?: "page_id" }
     | { database_id: IdRequest; type?: "database_id" }
-  properties:
-    | Record<
-        string,
-        | { title: Array<RichTextItemRequest>; type?: "title" }
-        | { rich_text: Array<RichTextItemRequest>; type?: "rich_text" }
-        | { number: number | null; type?: "number" }
-        | { url: TextRequest | null; type?: "url" }
-        | {
-            select:
-              | {
-                  id: StringRequest
-                  name?: TextRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-              | {
-                  name: TextRequest
-                  id?: StringRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-            type?: "select"
-          }
-        | {
-            multi_select: Array<
-              | {
-                  id: StringRequest
-                  name?: TextRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | {
-                  name: TextRequest
-                  id?: StringRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-            >
-            type?: "multi_select"
-          }
-        | {
-            people: Array<
-              | { id: IdRequest }
-              | {
-                  person: { email?: string }
-                  id: IdRequest
-                  type?: "person"
-                  name?: string | null
-                  avatar_url?: string | null
-                  object?: "user"
-                }
-              | {
-                  bot: EmptyObject | BotInfoResponse
-                  id: IdRequest
-                  type?: "bot"
-                  name?: string | null
-                  avatar_url?: string | null
-                  object?: "user"
-                }
-            >
-            type?: "people"
-          }
-        | { email: StringRequest | null; type?: "email" }
-        | { phone_number: StringRequest | null; type?: "phone_number" }
-        | { date: DateRequest | null; type?: "date" }
-        | { checkbox: boolean; type?: "checkbox" }
-        | { relation: Array<{ id: IdRequest }>; type?: "relation" }
-        | {
-            files: Array<
-              | InternalOrExternalFileWithNameRequest
-              | FileUploadWithOptionalNameRequest
-            >
-            type?: "files"
-          }
-        | {
-            status:
-              | {
-                  id: StringRequest
-                  name?: TextRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-              | {
-                  name: TextRequest
-                  id?: StringRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-            type?: "status"
-          }
-      >
-    | Record<
-        string,
-        | Array<RichTextItemRequest>
-        | number
-        | null
-        | TextRequest
-        | null
-        | {
-            id: StringRequest
-            name?: TextRequest
-            color?: SelectColor
-            description?: TextRequest | null
-          }
-        | null
-        | {
-            name: TextRequest
-            id?: StringRequest
-            color?: SelectColor
-            description?: TextRequest | null
-          }
-        | null
-        | Array<
-            | {
-                id: StringRequest
-                name?: TextRequest
-                color?: SelectColor
-                description?: TextRequest | null
-              }
-            | {
-                name: TextRequest
-                id?: StringRequest
-                color?: SelectColor
-                description?: TextRequest | null
-              }
-          >
-        | Array<
-            | { id: IdRequest }
-            | {
-                person: { email?: string }
-                id: IdRequest
-                type?: "person"
-                name?: string | null
-                avatar_url?: string | null
-                object?: "user"
-              }
-            | {
-                bot: EmptyObject | BotInfoResponse
-                id: IdRequest
-                type?: "bot"
-                name?: string | null
-                avatar_url?: string | null
-                object?: "user"
-              }
-          >
-        | StringRequest
-        | null
-        | DateRequest
-        | null
-        | boolean
-        | Array<{ id: IdRequest }>
-        | Array<
-            | InternalOrExternalFileWithNameRequest
-            | FileUploadWithOptionalNameRequest
-          >
-      >
+  properties: Record<
+    string,
+    | { title: Array<RichTextItemRequest>; type?: "title" }
+    | { rich_text: Array<RichTextItemRequest>; type?: "rich_text" }
+    | { number: number | null; type?: "number" }
+    | { url: TextRequest | null; type?: "url" }
+    | {
+        select:
+          | {
+              id: StringRequest
+              name?: TextRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+          | {
+              name: TextRequest
+              id?: StringRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+        type?: "select"
+      }
+    | {
+        multi_select: Array<
+          | {
+              id: StringRequest
+              name?: TextRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | {
+              name: TextRequest
+              id?: StringRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+        >
+        type?: "multi_select"
+      }
+    | {
+        people: Array<
+          | { id: IdRequest }
+          | {
+              person: { email?: string }
+              id: IdRequest
+              type?: "person"
+              name?: string | null
+              avatar_url?: string | null
+              object?: "user"
+            }
+          | {
+              bot: EmptyObject | BotInfoResponse
+              id: IdRequest
+              type?: "bot"
+              name?: string | null
+              avatar_url?: string | null
+              object?: "user"
+            }
+        >
+        type?: "people"
+      }
+    | { email: StringRequest | null; type?: "email" }
+    | { phone_number: StringRequest | null; type?: "phone_number" }
+    | { date: DateRequest | null; type?: "date" }
+    | { checkbox: boolean; type?: "checkbox" }
+    | { relation: Array<{ id: IdRequest }>; type?: "relation" }
+    | {
+        files: Array<
+          | InternalOrExternalFileWithNameRequest
+          | FileUploadWithOptionalNameRequest
+        >
+        type?: "files"
+      }
+    | {
+        status:
+          | {
+              id: StringRequest
+              name?: TextRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+          | {
+              name: TextRequest
+              id?: StringRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+        type?: "status"
+      }
+  >
   icon?: PageIconRequest | null
   cover?: PageCoverRequest | null
   content?: Array<BlockObjectRequest>
@@ -7372,166 +7306,100 @@ type UpdatePagePathParameters = {
 }
 
 type UpdatePageBodyParameters = {
-  properties?:
-    | Record<
-        string,
-        | { title: Array<RichTextItemRequest>; type?: "title" }
-        | { rich_text: Array<RichTextItemRequest>; type?: "rich_text" }
-        | { number: number | null; type?: "number" }
-        | { url: TextRequest | null; type?: "url" }
-        | {
-            select:
-              | {
-                  id: StringRequest
-                  name?: TextRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-              | {
-                  name: TextRequest
-                  id?: StringRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-            type?: "select"
-          }
-        | {
-            multi_select: Array<
-              | {
-                  id: StringRequest
-                  name?: TextRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | {
-                  name: TextRequest
-                  id?: StringRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-            >
-            type?: "multi_select"
-          }
-        | {
-            people: Array<
-              | { id: IdRequest }
-              | {
-                  person: { email?: string }
-                  id: IdRequest
-                  type?: "person"
-                  name?: string | null
-                  avatar_url?: string | null
-                  object?: "user"
-                }
-              | {
-                  bot: EmptyObject | BotInfoResponse
-                  id: IdRequest
-                  type?: "bot"
-                  name?: string | null
-                  avatar_url?: string | null
-                  object?: "user"
-                }
-            >
-            type?: "people"
-          }
-        | { email: StringRequest | null; type?: "email" }
-        | { phone_number: StringRequest | null; type?: "phone_number" }
-        | { date: DateRequest | null; type?: "date" }
-        | { checkbox: boolean; type?: "checkbox" }
-        | { relation: Array<{ id: IdRequest }>; type?: "relation" }
-        | {
-            files: Array<
-              | InternalOrExternalFileWithNameRequest
-              | FileUploadWithOptionalNameRequest
-            >
-            type?: "files"
-          }
-        | {
-            status:
-              | {
-                  id: StringRequest
-                  name?: TextRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-              | {
-                  name: TextRequest
-                  id?: StringRequest
-                  color?: SelectColor
-                  description?: TextRequest | null
-                }
-              | null
-            type?: "status"
-          }
-      >
-    | Record<
-        string,
-        | Array<RichTextItemRequest>
-        | number
-        | null
-        | TextRequest
-        | null
-        | {
-            id: StringRequest
-            name?: TextRequest
-            color?: SelectColor
-            description?: TextRequest | null
-          }
-        | null
-        | {
-            name: TextRequest
-            id?: StringRequest
-            color?: SelectColor
-            description?: TextRequest | null
-          }
-        | null
-        | Array<
-            | {
-                id: StringRequest
-                name?: TextRequest
-                color?: SelectColor
-                description?: TextRequest | null
-              }
-            | {
-                name: TextRequest
-                id?: StringRequest
-                color?: SelectColor
-                description?: TextRequest | null
-              }
-          >
-        | Array<
-            | { id: IdRequest }
-            | {
-                person: { email?: string }
-                id: IdRequest
-                type?: "person"
-                name?: string | null
-                avatar_url?: string | null
-                object?: "user"
-              }
-            | {
-                bot: EmptyObject | BotInfoResponse
-                id: IdRequest
-                type?: "bot"
-                name?: string | null
-                avatar_url?: string | null
-                object?: "user"
-              }
-          >
-        | StringRequest
-        | null
-        | DateRequest
-        | null
-        | boolean
-        | Array<{ id: IdRequest }>
-        | Array<
-            | InternalOrExternalFileWithNameRequest
-            | FileUploadWithOptionalNameRequest
-          >
-      >
+  properties?: Record<
+    string,
+    | { title: Array<RichTextItemRequest>; type?: "title" }
+    | { rich_text: Array<RichTextItemRequest>; type?: "rich_text" }
+    | { number: number | null; type?: "number" }
+    | { url: TextRequest | null; type?: "url" }
+    | {
+        select:
+          | {
+              id: StringRequest
+              name?: TextRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+          | {
+              name: TextRequest
+              id?: StringRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+        type?: "select"
+      }
+    | {
+        multi_select: Array<
+          | {
+              id: StringRequest
+              name?: TextRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | {
+              name: TextRequest
+              id?: StringRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+        >
+        type?: "multi_select"
+      }
+    | {
+        people: Array<
+          | { id: IdRequest }
+          | {
+              person: { email?: string }
+              id: IdRequest
+              type?: "person"
+              name?: string | null
+              avatar_url?: string | null
+              object?: "user"
+            }
+          | {
+              bot: EmptyObject | BotInfoResponse
+              id: IdRequest
+              type?: "bot"
+              name?: string | null
+              avatar_url?: string | null
+              object?: "user"
+            }
+        >
+        type?: "people"
+      }
+    | { email: StringRequest | null; type?: "email" }
+    | { phone_number: StringRequest | null; type?: "phone_number" }
+    | { date: DateRequest | null; type?: "date" }
+    | { checkbox: boolean; type?: "checkbox" }
+    | { relation: Array<{ id: IdRequest }>; type?: "relation" }
+    | {
+        files: Array<
+          | InternalOrExternalFileWithNameRequest
+          | FileUploadWithOptionalNameRequest
+        >
+        type?: "files"
+      }
+    | {
+        status:
+          | {
+              id: StringRequest
+              name?: TextRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+          | {
+              name: TextRequest
+              id?: StringRequest
+              color?: SelectColor
+              description?: TextRequest | null
+            }
+          | null
+        type?: "status"
+      }
+  >
   icon?: PageIconRequest | null
   cover?: PageCoverRequest | null
   archived?: boolean


### PR DESCRIPTION
This PR removes support for the legacy (pre-Q3-2021) shape for page `properties` parameters from `CreatePageBodyParameters` and `UpdatePageBodyParameters` in `src/api-endpoints.ts`.

This collapses the union type of {old properties shape, new properties shape} down to the new shape only.

In the old shape, `properties` was a fairly ambiguous `Record<string, ...>` mapping each property key to the property value (a union type across all possible property types' values) e.g.

```ts
{
  // ...
  "numberId": 24,
}
```

In the new shape (the only one we want to support going forward), the value must be wrapped in an object that uses the polymorphic `type` pattern with the actual value defined in a sub-object to disambiguate:

```ts
{
  // ...
  "numberId": {
    "type": "number",
    "number": 24
  }
}
```

This matches up with our responses in the API read path so most, if not all, integrations are likely already using syntax compatible with the new shape, but we'll probably have to cut a new major version for the JS SDK following this PR.