### PR TITLE
Include comment display name and file upload in intro API example

### DIFF
--- a/examples/intro-to-notion-api/intermediate/5-upload-file.js
+++ b/examples/intro-to-notion-api/intermediate/5-upload-file.js
@@ -51,6 +51,19 @@ async function appendBlockChildren(blockId, fileUploadId) {
           },
         },
       },
+      {
+        type: "paragraph",
+        paragraph: {
+          rich_text: [
+            {
+              type: "text",
+              text: {
+                content: "This is a test",
+              },
+            },
+          ],
+        },
+      },
     ],
   })
 }
@@ -68,11 +81,47 @@ async function main() {
     fileUpload.status
   )
 
-  const result = await appendBlockChildren(pageId, fileUpload.id)
+  // Append an image block with the file upload from above, and a text block,
+  // to the configured page.
+  const newBlocks = await appendBlockChildren(pageId, fileUpload.id)
+  const newBlockIds = newBlocks.results.map(block => block.id)
   console.log(
     "Appended block children; new list of block children is:",
-    result.results.map(block => block.id)
+    newBlockIds
   )
+
+  // Create a comment on the text block with the same image by providing
+  // the same file upload ID. Also use a custom display name.
+  const comment = await notion.comments.create({
+    parent: {
+      type: "block_id",
+      block_id: newBlockIds[1],
+    },
+    rich_text: [
+      {
+        type: "text",
+        text: { content: "I'm commenting on this block with an image:" },
+      },
+    ],
+    attachments: [
+      {
+        type: "file_upload",
+        file_upload_id: fileUpload.id,
+      },
+    ],
+    display_name: {
+      type: "custom",
+      custom: {
+        name: "Notion test auto commenter",
+      },
+    },
+  })
+
+  console.log("Comment ID:", comment.id)
+  console.log("Discussion ID:", comment.discussion_id)
+  console.log("Comment parent:", comment.parent)
+  console.log("Comment created by:", comment.created_by)
+  console.log("Comment display name:", comment.display_name)
 
   console.log("Done! Image added to page:", pageId)
 }


### PR DESCRIPTION
This PR updates `examples/intro-to-notion-api/intermediate/5-upload-file.js` with examples of the new Comment API features we're planning to roll out in the next major version (v4) of the JS SDK:
- Custom display names
- File upload attachments

Manually tested that the flow works in my test workspace in production:

```bash
$ node intermediate/5-upload-file.js
Created file upload with ID: 2234ea23-c619-8162-9249-00b27fbcf554
Uploaded page_id.png to file upload; status is now: uploaded
Appended block children; new list of block children is: [
  '2234ea23-c619-8113-947c-e0ac358fab0a',
  '2234ea23-c619-816a-95d5-effbf3533759'
]
Comment ID: 2234ea23-c619-8162-8118-001dd6bca2da
Discussion ID: 2234ea23-c619-81ac-9af2-001cfea309ae
Comment parent: { type: 'block_id', block_id: '2234ea23-c619-816a-95d5-effbf3533759' }
Comment created by: { object: 'user', id: '4d82069c-d101-4316-ac78-81b27b204498' }
Comment display name: { type: 'custom', resolved_name: 'Notion test auto commenter' }
Done! Image added to page: 2234ea23c619809db336c659b04d546a
```