### PR TITLE
Major version bump: v3.1.3 → v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Commits the result of `npm run major`

This release will include the following changes: https://github.com/makenotion/notion-sdk-js/compare/df95f350ce31c198b74e4d19dcfb02405004ec4f...ksinder-bump-major-version

Considering this "major" only due to https://github.com/makenotion/notion-sdk-js/commit/7f528653d84b6d90ea52357103fc69c628e39bd3 being a removal of deprecated API shape.