### PR TITLE
Support additional `headers` passed to `notion.request()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -127,6 +127,7 @@ export interface RequestParameters {
   query?: QueryParams
   body?: Record<string, unknown>
   formDataParams?: Record<string, string | FileParam>
+  headers?: Record<string, string>
   /**
    * To authenticate using public API token, `auth` should be passed as a
    * string. If you are trying to complete OAuth, then `auth` should be an object
@@ -212,6 +213,10 @@ export default class Client {
     }
 
     const headers: Record<string, string> = {
+      // Request-level custom additional headers can be provided, but
+      // don't allow them to override all other headers, e.g. the
+      // standard user agent.
+      ...args.headers,
       ...authorizationHeader,
       "Notion-Version": this.#notionVersion,
       "user-agent": this.#userAgent,

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -114,5 +114,27 @@ describe("Notion SDK Client", () => {
       assert("size" in formData["file"])
       expect(formData["file"].size).toEqual(4)
     })
+
+    it("accepts custom request-level headers", async () => {
+      await notion.request({
+        path: "comments",
+        method: "get",
+        headers: {
+          "X-Custom-Header": "custom-value",
+        },
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.notion.com/v1/comments",
+        expect.objectContaining({
+          method: "GET",
+          headers: expect.objectContaining({
+            "Notion-Version": expect.any(String),
+            "user-agent": expect.stringContaining("notionhq-client"),
+            "X-Custom-Header": "custom-value",
+          }),
+        })
+      )
+    })
   })
 })


### PR DESCRIPTION
- Support additional `headers` passed to `notion.request()`
- Bump version to 4.0.1 using `npm version patch`