### PR TITLE
Bump patch version to `4.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
This PR commits the result of running `npm version patch` to bump the latest version of the package to 4.0.2 ahead from publishing those changes (just this PR: https://github.com/makenotion/notion-sdk-js/commit/8a454376bd7d53e8e8bbeb83bf4b98ea2ff0ec93) to NPM.