### PR TITLE
Upgrade required version for TypeScript in `README.md` following version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ const blocks = await collectPaginatedAPI(notion.blocks.children.list, {
 This package supports the following minimum versions:
 
 - Runtime: `node >= 18`
-- Type definitions (optional): `typescript >= 4.5`
+- Type definitions (optional): `typescript >= 5.9`
 
 Earlier versions may still work, but we encourage people building new applications to upgrade to the current stable.
 


### PR DESCRIPTION
Upgrade the noted minimum version of TypeScript recommended for this package following https://github.com/makenotion/notion-sdk-js/pull/597