### PR TITLE
[v5] Fix `database_id` → `data_source_id` path params

### DIFF
--- a/examples/database-email-update/index.ts
+++ b/examples/database-email-update/index.ts
@@ -85,7 +85,7 @@ async function getTasksFromNotionDatabase(): Promise<Array<TaskResult>> {
     }
 
     const { results, next_cursor } = await notion.dataSources.query({
-      database_id: database.data_sources[0].id,
+      data_source_id: database.data_sources[0].id,
       start_cursor: cursor,
     })
     pages.push(...results)

--- a/examples/generate-random-data/index.ts
+++ b/examples/generate-random-data/index.ts
@@ -276,7 +276,7 @@ async function exerciseReading(
   console.log("\n\n********* Exercising Reading *********\n\n")
   // and read back what we just did
   const queryResponse = await notion.dataSources.query({
-    database_id: dataSourceId,
+    data_source_id: dataSourceId,
   })
   let numOldRows = 0
   for (const page of queryResponse.results) {
@@ -331,7 +331,7 @@ async function exerciseFilters(
   }
 
   const matchingSelectResults = await notion.dataSources.query({
-    database_id: dataSourceId,
+    data_source_id: dataSourceId,
     filter: queryFilterSelectFilterTypeBased,
   })
 
@@ -363,7 +363,7 @@ async function exerciseFilters(
 
   // Check we can search by id
   const matchingTextResults = await notion.dataSources.query({
-    database_id: dataSourceId,
+    data_source_id: dataSourceId,
     filter: textFilter,
   })
 

--- a/examples/intro-to-notion-api/intermediate/3-query-database.ts
+++ b/examples/intro-to-notion-api/intermediate/3-query-database.ts
@@ -37,7 +37,7 @@ async function queryDataSource(dataSourceId) {
   // property that is more recent than 2022-12-31. Use multiple filters with the AND/OR
   // options: https://developers.notion.com/reference/post-database-query-filter.
   const lastOrderedIn2023 = await notion.dataSources.query({
-    database_id: dataSourceId,
+    data_source_id: dataSourceId,
     filter: {
       property: "Last ordered",
       date: {

--- a/examples/intro-to-notion-api/intermediate/4-sort-database.ts
+++ b/examples/intro-to-notion-api/intermediate/4-sort-database.ts
@@ -39,7 +39,7 @@ async function queryAndSortDataSource(dataSourceId) {
   // can be filtered or sorted. Pass multiple sort objects to the "sorts" array to
   // apply more than one sorting rule.
   const lastOrderedIn2023Alphabetical = await notion.dataSources.query({
-    database_id: dataSourceId,
+    data_source_id: dataSourceId,
     filter: {
       property: "Last ordered",
       date: {

--- a/examples/notion-github-sync/index.ts
+++ b/examples/notion-github-sync/index.ts
@@ -83,7 +83,7 @@ async function getIssuesFromNotionDataSource() {
   const shouldContinue = true
   while (shouldContinue) {
     const { results, next_cursor } = await notion.dataSources.query({
-      database_id: database.data_sources[0].id,
+      data_source_id: database.data_sources[0].id,
       start_cursor: cursor,
     })
     pages.push(...results)

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -8189,7 +8189,7 @@ export const appendBlockChildren = {
 
 type GetDataSourcePathParameters = {
   // ID of a Notion data source.
-  database_id: IdRequest
+  data_source_id: IdRequest
 }
 
 export type GetDataSourceParameters = GetDataSourcePathParameters
@@ -8203,16 +8203,16 @@ export type GetDataSourceResponse =
  */
 export const getDataSource = {
   method: "get",
-  pathParams: ["database_id"],
+  pathParams: ["data_source_id"],
   queryParams: [],
   bodyParams: [],
 
   path: (p: GetDataSourcePathParameters): string =>
-    `data_sources/${p.database_id}`,
+    `data_sources/${p.data_source_id}`,
 } as const
 
 type UpdateDataSourcePathParameters = {
-  database_id: IdRequest
+  data_source_id: IdRequest
 }
 
 type UpdateDataSourceBodyParameters = {
@@ -8430,7 +8430,7 @@ export type UpdateDataSourceResponse =
  */
 export const updateDataSource = {
   method: "patch",
-  pathParams: ["database_id"],
+  pathParams: ["data_source_id"],
   queryParams: [],
   bodyParams: [
     "title",
@@ -8444,11 +8444,11 @@ export const updateDataSource = {
   ],
 
   path: (p: UpdateDataSourcePathParameters): string =>
-    `data_sources/${p.database_id}`,
+    `data_sources/${p.data_source_id}`,
 } as const
 
 type QueryDataSourcePathParameters = {
-  database_id: IdRequest
+  data_source_id: IdRequest
 }
 
 type QueryDataSourceQueryParameters = {
@@ -8514,7 +8514,7 @@ export type QueryDataSourceResponse = {
  */
 export const queryDataSource = {
   method: "post",
-  pathParams: ["database_id"],
+  pathParams: ["data_source_id"],
   queryParams: ["filter_properties"],
   bodyParams: [
     "sorts",
@@ -8526,7 +8526,7 @@ export const queryDataSource = {
   ],
 
   path: (p: QueryDataSourcePathParameters): string =>
-    `data_sources/${p.database_id}/query`,
+    `data_sources/${p.data_source_id}/query`,
 } as const
 
 type CreateDataSourceBodyParameters = {


### PR DESCRIPTION
This PR corrects the new data source endpoints' path param input to use `data_source_id` instead of `database_id` (better matching the nature of the ID it's accepting.) This applies to `notion.dataSources.{query,update,retrieve}`.