### PR TITLE
[v5] Sync API shape changes for `data_source` parents and search filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,17 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm test
+
+  typecheck-examples:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 20.x
+      - run: npm install
+      - run: npm run build
+      - run: npm run examples:install
+      - run: npm run examples:typecheck

--- a/examples/generate-random-data/index.ts
+++ b/examples/generate-random-data/index.ts
@@ -377,7 +377,7 @@ async function main() {
   const searchResults = await notion.search({
     filter: {
       property: "object",
-      value: "database",
+      value: "data_source",
     },
   })
 

--- a/examples/intro-to-notion-api/intermediate/5-upload-file.ts
+++ b/examples/intro-to-notion-api/intermediate/5-upload-file.ts
@@ -1,6 +1,6 @@
-import { Client } from "@notionhq/client"
+import { Client, isFullComment } from "@notionhq/client"
 import { config } from "dotenv"
-import { openAsBlob } from "fs"
+import { readFile } from "fs/promises"
 import { basename, join } from "path"
 
 config()
@@ -31,7 +31,7 @@ async function sendFileUpload(fileUploadId, filePath) {
     file_upload_id: fileUploadId,
     file: {
       filename: basename(filePath),
-      data: new Blob([await openAsBlob(filePath)], {
+      data: new Blob([await readFile(filePath)], {
         type: "image/png",
       }),
     },
@@ -118,10 +118,15 @@ async function main() {
   })
 
   console.log("Comment ID:", comment.id)
-  console.log("Discussion ID:", comment.discussion_id)
-  console.log("Comment parent:", comment.parent)
-  console.log("Comment created by:", comment.created_by)
-  console.log("Comment display name:", comment.display_name)
+
+  if (isFullComment(comment)) {
+    console.log("Discussion ID:", comment.discussion_id)
+    console.log("Comment parent:", comment.parent)
+    console.log("Comment created by:", comment.created_by)
+    console.log("Comment display name:", comment.display_name)
+  } else {
+    console.error("No read access to comment object")
+  }
 
   console.log("Done! Image & comment added to page:", pageId)
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "clean": "rm -rf ./build",
     "checkLoggedIn": "./scripts/verifyLoggedIn.sh",
     "install:examples": "for dir in examples/*/; do echo \"Installing dependencies in $dir...\"; (cd \"$dir\" && npm install); done",
-    "examples:install": "npm run install:examples"
+    "examples:install": "npm run install:examples",
+    "examples:typecheck": "for dir in examples/*/; do echo \"Typechecking $dir...\"; (cd \"$dir\" && npx tsc --noEmit) || exit 1; done"
   },
   "author": "",
   "license": "MIT",

--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -5099,6 +5099,12 @@ export type DataSourceObjectResponse = {
         // The ID of the parent block.
         block_id: string
       }
+    | {
+        // The parent type.
+        type: "data_source_id"
+        // The ID of the parent data source.
+        data_source_id: string
+      }
   // Whether the data source is inline.
   is_inline: boolean
   // Whether the data source is archived.
@@ -8717,7 +8723,7 @@ type SearchBodyParameters = {
   query?: string
   start_cursor?: string
   page_size?: number
-  filter?: { property: "object"; value: "page" | "database" }
+  filter?: { property: "object"; value: "page" | "data_source" }
 }
 
 export type SearchParameters = SearchBodyParameters


### PR DESCRIPTION
Sync Notion's latest public OpenAPI schema for `2025-09-03` to `src/api-endpoints.ts`:
- Add `data_source_id` as a valid type variant for the `DataSourceObjectResponse["parent"]`
- Change valid enum values for `SearchBodyParameters["filter"]["value"]` from `"page" | "database"` to `"page" | "data_source"`

In the latest commit, I also added typechecking of all `examples/` projects as part of CI so we can catch issues more systematically.