### PR TITLE
Add Notion ID extraction functions to helpers

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -199,3 +199,107 @@ export function isMentionRichTextItemResponse(
 ): richText is RichTextItemResponseCommon & MentionRichTextItemResponse {
   return richText.type === "mention"
 }
+
+/**
+ * Extracts a Notion ID from a Notion URL or returns the input if it's already a valid ID.
+ * 
+ * Prioritizes path IDs over query parameters to avoid extracting view IDs instead of database IDs.
+ * 
+ * @param urlOrId A Notion URL or ID string
+ * @returns The extracted UUID in standard format (with hyphens) or null if invalid
+ * 
+ * @example
+ * ```typescript
+ * // Database URL with view ID - extracts database ID, not view ID
+ * extractNotionId('https://notion.so/workspace/DB-abc123def456789012345678901234ab?v=viewid123')
+ * // Returns: 'abc123de-f456-7890-1234-5678901234ab' (database ID)
+ * 
+ * // Already formatted UUID
+ * extractNotionId('12345678-1234-1234-1234-123456789abc')
+ * // Returns: '12345678-1234-1234-1234-123456789abc'
+ * ```
+ */
+export function extractNotionId(urlOrId: string): string | null {
+  if (!urlOrId || typeof urlOrId !== 'string') {
+    return null
+  }
+
+  const trimmed = urlOrId.trim()
+
+  // Check if it's already a properly formatted UUID
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+  if (uuidRegex.test(trimmed)) {
+    return trimmed.toLowerCase()
+  }
+
+  // Check if it's a compact UUID (32 chars, no hyphens)
+  const compactUuidRegex = /^[0-9a-f]{32}$/i
+  if (compactUuidRegex.test(trimmed)) {
+    return formatUuid(trimmed)
+  }
+
+  // Extract from URL - prioritize path over query parameters
+  // This prevents extracting view IDs when database IDs are in the path
+  const pathMatch = trimmed.match(/\/[^/?#]*-([0-9a-f]{32})(?:[/?#]|$)/i)
+  if (pathMatch && pathMatch[1]) {
+    return formatUuid(pathMatch[1])
+  }
+
+  // Fallback to query parameters if no path ID found
+  const queryMatch = trimmed.match(/[?&](?:p|page_id|database_id)=([0-9a-f]{32})/i)
+  if (queryMatch && queryMatch[1]) {
+    return formatUuid(queryMatch[1])
+  }
+
+  // Last resort: any 32-char hex string in the URL
+  const anyMatch = trimmed.match(/([0-9a-f]{32})/i)
+  if (anyMatch && anyMatch[1]) {
+    return formatUuid(anyMatch[1])
+  }
+
+  return null
+}
+
+/**
+ * Formats a 32-character hex string into a standard UUID format.
+ * @param compactId 32-character hex string without hyphens
+ * @returns UUID with hyphens in standard format
+ */
+function formatUuid(compactId: string): string {
+  const clean = compactId.toLowerCase()
+  return `${clean.slice(0, 8)}-${clean.slice(8, 12)}-${clean.slice(12, 16)}-${clean.slice(16, 20)}-${clean.slice(20, 32)}`
+}
+
+/**
+ * Extracts a database ID from a Notion database URL.
+ * Convenience wrapper around `extractNotionId`.
+ */
+export function extractDatabaseId(databaseUrl: string): string | null {
+  return extractNotionId(databaseUrl)
+}
+
+/**
+ * Extracts a page ID from a Notion page URL.
+ * Convenience wrapper around `extractNotionId`.
+ */
+export function extractPageId(pageUrl: string): string | null {
+  return extractNotionId(pageUrl)
+}
+
+/**
+ * Extracts a block ID from a Notion URL with a block fragment.
+ * Looks for #block-<id> or #<id> patterns.
+ */
+export function extractBlockId(urlWithBlock: string): string | null {
+  if (!urlWithBlock || typeof urlWithBlock !== 'string') {
+    return null
+  }
+
+  // Look for block fragment in URL (#block-32chars or just #32chars)
+  const blockMatch = urlWithBlock.match(/#(?:block-)?([0-9a-f]{32})/i)
+  if (blockMatch && blockMatch[1]) {
+    return formatUuid(blockMatch[1])
+  }
+
+  return null
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,4 +175,8 @@ export {
   isFullUser,
   isFullComment,
   isFullPageOrDataSource,
+  extractNotionId,
+  extractDatabaseId,
+  extractPageId,
+  extractBlockId,
 } from "./helpers"

--- a/test/id-extraction.test.ts
+++ b/test/id-extraction.test.ts
@@ -1,0 +1,87 @@
+import {
+  extractNotionId,
+  extractDatabaseId,
+  extractPageId,
+  extractBlockId,
+} from "../src"
+
+describe("ID Extraction Utilities", () => {
+  describe("extractNotionId", () => {
+    it("should extract ID from standard Notion URLs", () => {
+      const examples = [
+        {
+          url: "https://www.notion.so/myworkspace/My-Database-abc123def456789012345678901234ab",
+          expected: "abc123de-f456-7890-1234-5678901234ab"
+        },
+        {
+          url: "https://notion.site/Database-Name-123456781234123412341234567890ab",
+          expected: "12345678-1234-1234-1234-1234567890ab"
+        }
+      ]
+
+      examples.forEach(({ url, expected }) => {
+        expect(extractNotionId(url)).toBe(expected)
+      })
+    })
+
+    it("should prioritize path ID over query parameters", () => {
+      // This is the key fix - database ID in path should be extracted, not view ID in query
+      const url = "https://notion.so/workspace/MyDB-abc123def456789012345678901234ab?v=def456789012345678901234abcdef12"
+      const result = extractNotionId(url)
+      expect(result).toBe("abc123de-f456-7890-1234-5678901234ab") // DB ID, not view ID
+    })
+
+    it("should use query parameters when no path ID available", () => {
+      const url = "https://notion.so/share?p=abc123def456789012345678901234ab"
+      const result = extractNotionId(url)
+      expect(result).toBe("abc123de-f456-7890-1234-5678901234ab")
+    })
+
+    it("should handle already formatted UUIDs", () => {
+      const uuid = "12345678-1234-1234-1234-123456789abc"
+      expect(extractNotionId(uuid)).toBe("12345678-1234-1234-1234-123456789abc")
+    })
+
+    it("should format compact UUIDs", () => {
+      const compactUuid = "123456781234123412341234567890ab"
+      expect(extractNotionId(compactUuid)).toBe("12345678-1234-1234-1234-1234567890ab")
+    })
+
+    it("should return null for invalid inputs", () => {
+      const invalidInputs = ["", "not-a-url", "12345", null, undefined]
+      invalidInputs.forEach(input => {
+        expect(extractNotionId(input as any)).toBe(null)
+      })
+    })
+  })
+
+  describe("extractDatabaseId", () => {
+    it("should extract database ID", () => {
+      const url = "https://www.notion.so/Tasks-abc123def456789012345678901234ab"
+      expect(extractDatabaseId(url)).toBe("abc123de-f456-7890-1234-5678901234ab")
+    })
+  })
+
+  describe("extractPageId", () => {
+    it("should extract page ID", () => {
+      const url = "https://www.notion.so/My-Page-123456781234123412341234567890ab"
+      expect(extractPageId(url)).toBe("12345678-1234-1234-1234-1234567890ab")
+    })
+  })
+
+  describe("extractBlockId", () => {
+    it("should extract block ID from fragment", () => {
+      const url = "https://www.notion.so/Page#block-def456789012345678901234abcdef12"
+      expect(extractBlockId(url)).toBe("def45678-9012-3456-7890-1234abcdef12")
+    })
+
+    it("should extract block ID without block- prefix", () => {
+      const url = "https://www.notion.so/Page#def456789012345678901234abcdef12"
+      expect(extractBlockId(url)).toBe("def45678-9012-3456-7890-1234abcdef12")
+    })
+
+    it("should return null if no block fragment", () => {
+      expect(extractBlockId("https://www.notion.so/Page")).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
## Description

This adds small helper functions to extract Notion IDs (database, page, block) from URLs.  
It makes it easier to work with Notion links by always giving back the correct UUID, even when URLs contain extra parameters like `?v=` for views.  

- `extractNotionId()` – core function  
- `extractDatabaseId()`, `extractPageId()`, `extractBlockId()` – simple wrappers  
- Works with common URL formats (`notion.so`, `notion.site`, shared links, block anchors, etc.)  
- Returns `null` if no valid ID is found  
- No breaking changes, just extra helpers  

---

## How was this change tested?

 [X] Added unit tests in `test/id-extraction.test.ts`  
  - Covers database URLs with view params  
  - Page share links (`?p=`)  
  - Block fragments (`#block-...`)  
  - Compact and hyphenated UUIDs  
  - Invalid inputs return `null`  

[X] Manually tested with my own Notion databases, pages, and blocks  

---

## Screenshots

**Example:**

```ts
const dbId = extractDatabaseId("https://www.notion.so/workspace/MyDB-abc123...?v=viewid456");
// -> "abc123de-f456-7890-1234-5678901234ab"