### PR TITLE
Bump prerelease version: `5.0.0-rc.0` → `5.0.0-rc.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notionhq/client",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notionhq/client",
-      "version": "5.0.0-rc.0",
+      "version": "5.0.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "28.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0-rc.1",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Description

Following up on https://github.com/makenotion/notion-sdk-js/pull/607, this PR commits the result of `npm version prerelease`, which bumps the package version to `5.0.0-rc.1` ahead of publishing this on NPM.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

N/A -- existing CI is sufficient

## Screenshots

N/A