### PR TITLE
Bump SDK major version to `v5.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notionhq/client",
-  "version": "5.0.0-rc.1",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notionhq/client",
-      "version": "5.0.0-rc.1",
+      "version": "5.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "28.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "5.0.0-rc.1",
+  "version": "5.0.0",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Description

This PR commits the result of `npm version major` to finalize the initial `v5.0.0` official release of the SDK.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

## Screenshots

N/A