### PR TITLE
Add `request_id` to `Client` log lines

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -178,7 +178,7 @@ export default class Client {
   /**
    * Sends a request.
    */
-  public async request<ResponseBody>(
+  public async request<ResponseBody extends object>(
     args: RequestParameters
   ): Promise<ResponseBody> {
     const { path, method, query, body, formDataParams, auth } = args
@@ -272,7 +272,13 @@ export default class Client {
       }
 
       const responseJson: ResponseBody = JSON.parse(responseText)
-      this.log(LogLevel.INFO, "request success", { method, path })
+      this.log(LogLevel.INFO, "request success", {
+        method,
+        path,
+        ...("request_id" in responseJson && responseJson.request_id
+          ? { requestId: responseJson.request_id }
+          : {}),
+      })
       return responseJson
     } catch (error: unknown) {
       if (!isNotionClientError(error)) {
@@ -283,6 +289,9 @@ export default class Client {
       this.log(LogLevel.WARN, "request fail", {
         code: error.code,
         message: error.message,
+        ...("request_id" in error && error.request_id
+          ? { requestId: error.request_id }
+          : {}),
       })
 
       if (isHTTPResponseError(error)) {


### PR DESCRIPTION
## Description

This PR parses `request_id` from the response of Notion API requests in `errors.ts` and includes them in the logger log lines in `Client.ts`. The idea is to encourage providing these in issue reports to Notion, so support teams can more easily debug issues.

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Manually tested a failing request and a succeeding request and confirmed the `request_id` is included in the log lines for both.

## Screenshots

```ts
@notionhq/client warn: request fail {
  code: 'unauthorized',
  message: 'API token is invalid.',
  requestId: '83843712-fa08-452b-9282-0c9dcbdcb51f'
}
```

```ts
Querying database...
@notionhq/client info: request start {
  method: 'post',
  path: 'data_sources/bb1734fe-3d6c-44e1-8984-9525023c482f/query'
}
@notionhq/client info: request success {
  method: 'post',
  path: 'data_sources/bb1734fe-3d6c-44e1-8984-9525023c482f/query',
  requestId: '895abceb-15a0-47e0-91d3-84c26dfd3749'
}
```