### PR TITLE
Fix idempotency in NPM publish workflow; add increment-version workflow

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,0 +1,52 @@
+name: Increment Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: "Version type to increment"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - premajor
+
+permissions:
+  contents: write
+
+jobs:
+  increment-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        run: |
+          npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Update package-lock.json
+        run: npm install
+
+      - name: Commit and push changes
+        run: |
+          git add package.json package-lock.json
+          git commit -m "Bump version to v${NEW_VERSION}"
+          git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
+          git push origin main
+          git push origin "v${NEW_VERSION}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm run test
-      - run: npm publish --ignore-scripts
       - run: |
           PACKAGE_NAME=$(jq -r '.name' package.json)
           PACKAGE_VERSION=$(jq -r '.version' package.json)
@@ -36,5 +35,5 @@ jobs:
             echo "Package $PACKAGE_NAME@$PACKAGE_VERSION already exists. Skipping publish."
           else
             echo "Publishing $PACKAGE_NAME@$PACKAGE_VERSION..."
-            npm publish
+            npm publish --ignore-scripts
           fi


### PR DESCRIPTION
## Description

**Summary**: 1 logic fix to the NPM publish GitHub Action, and 1 net-new (manual trigger only) Action `increment-version.yml` to bump the patch, minor, major, or premajor version of `@notionhq/client`.

### Fix idempotency in NPM publish workflow

This PR cleans ups an idempotency issue where we have two `npm publish` calls in the `publish.yml` action added in #620, leading to duplicate steps: https://github.com/makenotion/notion-sdk-js/actions/runs/17698864508

<kbd>

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/aa7a290f-afcb-4ea0-9f5c-da5569f973d7" />

</kbd>

The `npm publish` happened correctly, ignoring the pre-publish script (`checkLoggedIn`), but then I had a stray `npm publish` without `--ignore-scripts` afterwards. We need to keep the latter call (since it correctly branches on whether there's a version to upgrade) but add the `--ignore-scripts` flag.

### Add increment-version workflow

Introduce a new GitHub Action we can use to fully automate the version bump & publish workflow! You just need to specify what type of version bump is happening in the Actions UI, and trigger it. It will commit to `main` with the appropriate version bump, which will then trigger the `publish.yml` workflow to publish to NPM 🎉

This completes the automation pipeline of our bump-version-and-publish process.

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

The first change is straightforward and a clear bugfix in the bash script, but the second is worth testing. Unfortunately, we can't really do more than manually inspect the GitHub workflow and iterate from any issues the next time we bump the version, since we don't really have a good "sandbox" for testing new versions currently.

## Screenshots

N/A