### PR TITLE
API schema sync: remove `data_source_id` type from `DataSource.database_parent`

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -851,13 +851,9 @@ export type DataSourceObjectResponse = {
   description: Array<RichTextItemResponse>
   // The parent of the data source.
   parent: ParentOfDataSourceResponse
-  // The parent of the data source's containing database.
-  database_parent:
-    | PageIdParentForBlockBasedObjectResponse
-    | WorkspaceParentForBlockBasedObjectResponse
-    | DatabaseParentResponse
-    | BlockIdParentForBlockBasedObjectResponse
-    | DataSourceParentResponse
+  // The parent of the data source's containing database. This is typically a page, block,
+  // or workspace, but can be another database in the case of wikis.
+  database_parent: ParentOfDatabaseResponse
   // Whether the data source is inline.
   is_inline: boolean
   // Whether the data source is archived.
@@ -1910,6 +1906,12 @@ export type RichTextItemResponseCommon = {
   annotations: AnnotationResponse
 }
 
+type ParentOfDatabaseResponse =
+  | PageIdParentForBlockBasedObjectResponse
+  | WorkspaceParentForBlockBasedObjectResponse
+  | DatabaseParentResponse
+  | BlockIdParentForBlockBasedObjectResponse
+
 export type PartialCommentObjectResponse = {
   // The comment object type name.
   object: "comment"
@@ -2042,12 +2044,9 @@ export type DatabaseObjectResponse = {
   title: Array<RichTextItemResponse>
   // The description of the database.
   description: Array<RichTextItemResponse>
-  // The parent of the database.
-  parent:
-    | PageIdParentForBlockBasedObjectResponse
-    | WorkspaceParentForBlockBasedObjectResponse
-    | DatabaseParentResponse
-    | BlockIdParentForBlockBasedObjectResponse
+  // The parent of the database. This is typically a page, block, or workspace, but can be
+  // another database in the case of wikis.
+  parent: ParentOfDatabaseResponse
   // Whether the database is inline.
   is_inline: boolean
   // Whether the database is in the trash.


### PR DESCRIPTION
## Description

This PR syncs the latest Notion API schema to the TS SDK `src/api-endpoints.ts`. The changes are generally minor and cosmetic, though there is one change to note that's technically backwards-incompatible in the TypeScript types:
- Consolidate `DataSourceObjectResponse["database_parent"]` and `DatabaseObjectResponse["parent"]` into one shared `type ParentOfDatabaseResponse`. 
  - `ParentOfDatabaseResponse` does **not** include `DataSourceParentResponse`, whereas previously the `data_source_id` variant was (erroneously, and inconsistently) included in `DataSourceObjectResponse["database_parent"]`
- Databases can't have a data source parent in practice (even in wiki scenarios)
- Add documentation string to `DataSourceObjectResponse["database_parent"]` and `DatabaseObjectResponse["parent"]`

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Relying on existing test coverage and lint in CI, since this is a small, automated change to types.

## Screenshots

N/A