### PR TITLE
Fix increment-version workflow to create a PR

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   increment-version:
@@ -45,10 +46,22 @@ jobs:
       - name: Update package-lock.json
         run: npm install
 
-      - name: Commit and push changes
+      - name: Create branch and commit changes
         run: |
+          BRANCH_NAME="version-bump-v${NEW_VERSION}"
+          git checkout -b "$BRANCH_NAME"
           git add package.json package-lock.json
           git commit -m "Bump version to v${NEW_VERSION}"
-          git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
-          git push origin main
-          git push origin "v${NEW_VERSION}"
+          git push origin "$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "Bump version to v${NEW_VERSION}" \
+            --body "This PR bumps the version to v${NEW_VERSION} using npm version ${{ github.event.inputs.version_type }}." \
+            --base main \
+            --head "${BRANCH_NAME}" \
+            --assignee "${{ github.actor }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC
-  contents: read
+  contents: write # Required to create and push tags
 
 jobs:
   publish:
@@ -30,7 +30,8 @@ jobs:
       - run: npm run build
       - run: npm run lint
       - run: npm run test
-      - run: |
+      - name: Publish to npm
+        run: |
           PACKAGE_NAME=$(jq -r '.name' package.json)
           PACKAGE_VERSION=$(jq -r '.version' package.json)
           if npm view "$PACKAGE_NAME" versions | grep -q "$PACKAGE_VERSION"; then
@@ -39,3 +40,12 @@ jobs:
             echo "Publishing $PACKAGE_NAME@$PACKAGE_VERSION..."
             npm publish --ignore-scripts
           fi
+
+      - name: Create and push tag
+        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'Bump version to')
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          VERSION=$(jq -r '.version' package.json)
+          git tag -a "v${VERSION}" -m "v${VERSION}"
+          git push origin "v${VERSION}"


### PR DESCRIPTION
## Description

- **Fix the Git mechanics of the bump version workflow**, since currently it hits the `main` protected branch rule [issue](https://github.com/makenotion/notion-sdk-js/actions/runs/18478122676/job/52647175500) trying to commit directly. Instead, we should **create a PR** and assign it to whoever triggered the version bump workflow.
- **Add a step to the automatic NPM publish workflow to automatically push tags for new versions**, so we get the new `v<#>` tags as soon as the PR created for version bumping is merged to `main`.

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Will manually validate these changes after merging this PR, and iterate forward on any issues, for simplicity (to avoid confusion from running these workflows on non-`main` branches which wouldn't be the usual workflow.)

## Screenshots

N/A