### PR TITLE
Sync api-endpoints: support templates in Update Page

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -3588,6 +3588,13 @@ type UpdatePageBodyParameters = {
   // Whether the page should be locked from editing in the Notion app UI. If not provided,
   // the locked state will not be updated.
   is_locked?: boolean
+  template?:
+    | { type: "default" }
+    | { type: "template_id"; template_id: IdRequest }
+  // Whether to erase all existing content from the page. When used with a template, the
+  // template content replaces the existing content. When used without a template, simply
+  // clears the page content.
+  erase_content?: boolean
   archived?: boolean
   in_trash?: boolean
 }
@@ -3609,6 +3616,8 @@ export const updatePage = {
     "icon",
     "cover",
     "is_locked",
+    "template",
+    "erase_content",
     "archived",
     "in_trash",
   ],


### PR DESCRIPTION
## Description

This PR adds support for two new optional parameters in the `UpdatePageBodyParameters`:
- `erase_content`: boolean to clear all current children of the page
- `template`: either `{ type: "default" }` or `{ type: "template_id"; template_id: IdRequest }` to specify a template to apply onto an existing page (template content is appended, and properties are merged the same way as for `pages.create`)

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Automated file sync; no manual code changes in this PR. Relying on typechecking and existing tests in CI.

## Screenshots

N/A