### PR TITLE
Fix tiny syntax error in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ const { Client } = require("@notionhq/client")
 // Initializing a client
 const notion = new Client({
   auth: process.env.NOTION_TOKEN,
-})
+});
 ```
 
 Make a request to any Notion API endpoint.
 
 ```js
-;(async () => {
+(async () => {
   const listUsersResponse = await notion.users.list({})
 })()
 ```


### PR DESCRIPTION
## Description
Tiny little fix, the semicolon in the first usage example block landed at the start of the second block.
