### PR TITLE
Sync api-endpoints: add `position` to `AppendBlockChildrenParameters`

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -919,6 +919,11 @@ type CommentParentResponse =
   | PageIdCommentParentResponse
   | BlockIdCommentParentResponse
 
+type ContentPositionSchema =
+  | { type: "after_block"; after_block: { id: IdRequest } }
+  | { type: "start" }
+  | { type: "end" }
+
 type ContentWithExpressionRequest = { expression: string }
 
 type ContentWithRichTextAndColorRequest = {
@@ -2313,6 +2318,11 @@ export type PageObjectResponse = {
   last_edited_by: PartialUserObjectResponse
 }
 
+type PagePositionSchema =
+  | { type: "after_block"; after_block: { id: IdRequest } }
+  | { type: "page_start" }
+  | { type: "page_end" }
+
 type PagePropertyValueWithIdResponse = IdObjectResponse &
   (SimpleOrArrayPropertyValueResponse | PartialRollupPropertyResponse)
 
@@ -3669,10 +3679,7 @@ type CreatePageBodyParameters = {
     | { type: "none" }
     | { type: "default" }
     | { type: "template_id"; template_id: IdRequest }
-  position?:
-    | { type: "after_block"; after_block: { id: IdRequest } }
-    | { type: "page_start" }
-    | { type: "page_end" }
+  position?: PagePositionSchema
 }
 
 export type CreatePageParameters = CreatePageBodyParameters
@@ -4219,6 +4226,7 @@ type AppendBlockChildrenPathParameters = {
 type AppendBlockChildrenBodyParameters = {
   children: Array<BlockObjectRequest>
   after?: IdRequest
+  position?: ContentPositionSchema
 }
 
 export type AppendBlockChildrenParameters = AppendBlockChildrenPathParameters &
@@ -4240,7 +4248,7 @@ export const appendBlockChildren = {
   method: "patch",
   pathParams: ["block_id"],
   queryParams: [],
-  bodyParams: ["children", "after"],
+  bodyParams: ["children", "after", "position"],
 
   path: (p: AppendBlockChildrenPathParameters): string =>
     `blocks/${p.block_id}/children`,


### PR DESCRIPTION
## Description

- This PR syncs the latest Notion API schema to the TS/JS SDK repo `src/api-endpoints.ts`.
- Specifically, this change is a backwards-compatible improvement to support a more expressive `position` parameter in the `PATCH /v1/blocks/:block_id/children` body to append at a specific position in the parent's children array.
  - The parameter cannot be used with the older `after` parameter, which will be officially removed in the next public API version.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Existing automated linting and test coverage are sufficient.

## Screenshots

N/A