### PR TITLE
Sync api-endpoints: add list_start_index and list_format

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -926,6 +926,13 @@ type ContentPositionSchema =
 
 type ContentWithExpressionRequest = { expression: string }
 
+type ContentWithRichTextAndColorAndListResponse = {
+  rich_text: Array<RichTextItemResponse>
+  color: ApiColor
+  list_start_index?: number
+  list_format?: NumberedListFormat
+}
+
 type ContentWithRichTextAndColorRequest = {
   rich_text: Array<RichTextItemRequest>
   color?: ApiColor
@@ -935,14 +942,6 @@ type ContentWithRichTextAndColorResponse = {
   rich_text: Array<RichTextItemResponse>
   color: ApiColor
 }
-
-type NumberedListFormat = "numbers" | "letters" | "roman"
-
-type ContentWithRichTextAndColorAndListResponse =
-  ContentWithRichTextAndColorResponse & {
-    list_start_index?: number
-    list_format?: NumberedListFormat
-  }
 
 type ContentWithRichTextRequest = { rich_text: Array<RichTextItemRequest> }
 
@@ -2248,6 +2247,8 @@ type NumberSimplePropertyValueResponse = {
   type: "number"
   number: number | null
 }
+
+type NumberedListFormat = "numbers" | "letters" | "roman"
 
 export type NumberedListItemBlockObjectResponse = {
   type: "numbered_list_item"


### PR DESCRIPTION
## Description

Aligning with API changes, add `list_start_index` and `list_format` for `numbered_list_item`

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)
