### PR TITLE
Prevent path traversal in `Client.request()`

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -10,6 +10,7 @@ import {
   isHTTPResponseError,
   isNotionClientError,
   RequestTimeoutError,
+  validateRequestPath,
 } from "./errors"
 import { pick } from "./utils"
 import {
@@ -188,6 +189,8 @@ export default class Client {
     args: RequestParameters
   ): Promise<ResponseBody> {
     const { path, method, query, body, formDataParams, auth } = args
+
+    validateRequestPath(path)
 
     this.log(LogLevel.INFO, "request start", { method, path })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ export {
   APIResponseError,
   UnknownHTTPResponseError,
   RequestTimeoutError,
+  InvalidPathParameterError,
   // Error helpers
   isNotionClientError,
 } from "./errors"


### PR DESCRIPTION
## Description

Prevent path parameters (block_id, page_id, database_id, etc.) from containing path traversal sequences (..) that could alter the requested API endpoint. The validation checks for both literal (..) and URL-encoded (%2e%2e) variants to defend against multiple encoding methods.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)

Added comprehensive test suite covering literal path traversal (..), URL-encoded variants (%2e%2e, mixed case), fully encoded paths (%2e%2e%2f), and validation that valid UUIDs continue to work.