### PR TITLE
Add manual workflow dispatch trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch or ref to run CI on"
+        required: false
+        default: ""
 
 jobs:
   build-and-test:
@@ -20,6 +26,8 @@ jobs:
     steps:
       # v5.0.0
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - name: Use Node.js ${{ matrix.node-version }}
         # v5.0.0
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444


### PR DESCRIPTION
## Description

Enable manual triggering of the CI workflow from the GitHub UI on any branch. This allows running CI on branches created by the increment-version workflow, which use GITHUB_TOKEN and don't automatically trigger push-based workflows (as per GitHub's intentional limitation to prevent infinite loops).

## How was this change tested?

- [x] Manual verification of workflow syntax