### PR TITLE
Update transcription block response shape

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -53,6 +53,13 @@ type ApiColor =
   | "pink_background"
   | "red_background"
 
+type ApiTranscriptionStatus =
+  | "transcription_not_started"
+  | "transcription_paused"
+  | "transcription_in_progress"
+  | "summary_in_progress"
+  | "notes_ready"
+
 type ArrayBasedPropertyValueResponse =
   | TitleArrayBasedPropertyValueResponse
   | RichTextArrayBasedPropertyValueResponse
@@ -448,6 +455,7 @@ export type BlockObjectResponse =
   | LinkToPageBlockObjectResponse
   | TableBlockObjectResponse
   | TableRowBlockObjectResponse
+  | TranscriptionBlockObjectResponse
   | EmbedBlockObjectResponse
   | BookmarkBlockObjectResponse
   | ImageBlockObjectResponse
@@ -3355,6 +3363,43 @@ export type ToggleBlockObjectResponse = {
   archived: boolean
   in_trash: boolean
 }
+
+export type TranscriptionBlockObjectResponse = {
+  type: "transcription"
+  transcription: TranscriptionBlockResponse
+  parent: ParentForBlockBasedObjectResponse
+  object: "block"
+  id: string
+  created_time: string
+  created_by: PartialUserObjectResponse
+  last_edited_time: string
+  last_edited_by: PartialUserObjectResponse
+  has_children: boolean
+  archived: boolean
+  in_trash: boolean
+}
+
+type TranscriptionBlockResponse = {
+  title?: Array<RichTextItemResponse>
+  status?: ApiTranscriptionStatus
+  children?: TranscriptionChildrenResponse
+  calendar_event?: TranscriptionCalendarEventResponse
+  recording?: TranscriptionRecordingResponse
+}
+
+type TranscriptionCalendarEventResponse = {
+  start_time: string
+  end_time: string
+  attendees?: Array<IdRequest>
+}
+
+type TranscriptionChildrenResponse = {
+  summary_block_id?: IdRequest
+  notes_block_id?: IdRequest
+  transcript_block_id?: IdRequest
+}
+
+type TranscriptionRecordingResponse = { start_time?: string; end_time?: string }
 
 type UniqueIdDatabasePropertyConfigResponse = {
   // Always `unique_id`


### PR DESCRIPTION
## Description

Previously, `transcription` blocks were treated as unsupported block types in the Public API. This change exposes them as a first-class response type, surfacing meeting notes metadata — without embedding raw transcript contents.

**Key changes:**

- **`transcription` joins `BlockObjectResponse`** — the block type is now a recognized union member, so existing type guards and exhaustive switches cover it automatically.
- **`title` (`rich_text[]`)** — the display name of the meeting notes session, rendered as a standard rich text array.
- **`status` (`ApiTranscriptionStatus`)** — reflects the current lifecycle stage of the transcription, mapped from internal state machine states to a stable public vocabulary: `transcription_not_started`, `transcription_paused`, `transcription_in_progress`, `summary_in_progress`, `notes_ready`.
- **`children` (`TranscriptionChildrenResponse`)** — pointers to the three related content blocks (`summary_block_id`, `notes_block_id`, `transcript_block_id`). Raw transcript content is intentionally not embedded; clients follow these UUIDs to fetch content via `GET /blocks/:id`.
- **`calendar_event` (`TranscriptionCalendarEventResponse`)** — metadata from the associated calendar event: `start_time`, `end_time` (ISO 8601), and optional `attendees` (user IDs).
- **`recording` (`TranscriptionRecordingResponse`)** — the actual recording window derived from state history: `start_time` is the earliest `transcribing` entry, `end_time` is the latest `summarizing` entry, both rounded down to the nearest minute.

**Example response:**

```json
{
  "object": "block",
  "type": "transcription",
  "transcription": {
    "title": [{ "plain_text": "Team Sync" }],
    "status": "summary_in_progress",
    "children": {
      "summary_block_id": "<uuid>",
      "notes_block_id": "<uuid>",
      "transcript_block_id": "<uuid>"
    },
    "calendar_event": {
      "attendees": ["<user-uuid>"],
      "start_time": "2026-02-24T10:00:00.000Z",
      "end_time": "2026-02-24T10:45:00.000Z"
    },
    "recording": {
      "start_time": "2026-02-24T10:00:00.000Z",
      "end_time": "2026-02-24T10:45:00.000Z"
    }
  }
}
```

## How was this change tested?

- [x] Updated the Notion Public API server to correctly serialize `transcription` block responses, with integration tests covering the full response shape
- [x] Transformed the internal block types into the SDK response types defined here
- [x] Locally built the package via `npm run build` and linked it locally via `npm run link`
- [x] Ran manual test scripts fetching live transcription blocks and validating the response against the new types

### Example bun script
```typescript
import { Client, isFullBlock } from "@notionhq/client";

const client = new Client({
  auth: process.env.NOTION_KEY,
});

// Fetch data from hardcoded transcription block ID
const BLOCK_ID = "d7b3c8f4-9e6e-4c1a-b5b8-2c0f4a0c5b8e";
const block = await client.blocks.retrieve({ block_id: BLOCK_ID });

const isTranscriptionBlock =
  isFullBlock(block) && block.type === "transcription";
if (!isTranscriptionBlock) {
  throw new Error("Block is not a transcription block");
}

const children = block.transcription.children;
if (!children) {
  throw new Error("No children found");
}

// Summary tab ID
const summaryTabId = children.summary_block_id;

// Other available tab IDs available on the transcription block
const notesTabId = children.notes_block_id;
const transcriptTabId = children.transcript_block_id;

if (!summaryTabId) {
  throw new Error("No summary block ID found");
}

// Get all blocks that make up the summary tab
const { results } = await client.blocks.children.list({
  block_id: summaryTabId,
});

results.forEach((result) => console.log(result.id));
```