### PR TITLE
Sync api-endpoints: unsupported block type, update page docstring tweak

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -3450,7 +3450,11 @@ type UniqueIdSimplePropertyValueResponse = {
 
 export type UnsupportedBlockObjectResponse = {
   type: "unsupported"
-  unsupported: EmptyObject
+  unsupported: {
+    // The underlying block type that is not currently supported by the Public API. Example
+    // values include: tab, form, button, drive.
+    block_type: string
+  }
   parent: ParentForBlockBasedObjectResponse
   object: "block"
   id: string
@@ -3917,7 +3921,7 @@ export type UpdatePageParameters = UpdatePagePathParameters &
 export type UpdatePageResponse = PageObjectResponse | PartialPageObjectResponse
 
 /**
- * Update page properties
+ * Update page
  */
 export const updatePage = {
   method: "patch",


### PR DESCRIPTION
## Description

This PR syncs `src/api-endpoints.ts` to Notion's latest public [OpenAPI schema](https://developers.notion.com/openapi.json). The specific changes included in this automated regen are:
- New `string` field `unsupported[block_type]` in `UnsupportedBlockObjectResponse` to provide a hint on what an underlying unsupported block type is
- Minor TSDoc change for `updatePage` endpoint: remove "properties" suffix from API name; just "Update page" now.
  - This reflects the fact that the endpoint does more than just updating properties/schema

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Relying on existing lint and typecheck; minor codegen'd change.

## Screenshots

N/A