### PR TITLE
feat: add meeting notes query support with attendees property typing

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -162,7 +162,10 @@ import {
   type ListCustomEmojisParameters,
   type ListCustomEmojisResponse,
   listCustomEmojis,
+  type QueryMeetingNotesResponse,
+  queryMeetingNotes,
 } from "./api-endpoints"
+import type { QueryMeetingNotesParameters } from "./meeting-notes"
 import {
   version as PACKAGE_VERSION,
   name as PACKAGE_NAME,
@@ -693,6 +696,23 @@ export default class Client {
           method: listBlockChildren.method,
           query: pick(args, listBlockChildren.queryParams),
           body: pick(args, listBlockChildren.bodyParams),
+          auth: args?.auth,
+        })
+      },
+    },
+
+    meetingNotes: {
+      /**
+       * Query meeting notes
+       */
+      query: (
+        args: WithAuth<QueryMeetingNotesParameters>
+      ): Promise<QueryMeetingNotesResponse> => {
+        return this.request<QueryMeetingNotesResponse>({
+          path: queryMeetingNotes.path(),
+          method: queryMeetingNotes.method,
+          query: pick(args, queryMeetingNotes.queryParams),
+          body: pick(args, queryMeetingNotes.bodyParams),
           auth: args?.auth,
         })
       },

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -162,9 +162,11 @@ import {
   type ListCustomEmojisParameters,
   type ListCustomEmojisResponse,
   listCustomEmojis,
+} from "./api-endpoints"
+import {
   type QueryMeetingNotesResponse,
   queryMeetingNotes,
-} from "./api-endpoints"
+} from "./api-endpoints/meeting-notes"
 import type { QueryMeetingNotesParameters } from "./meeting-notes"
 import {
   version as PACKAGE_VERSION,

--- a/src/api-endpoints/meeting-notes.ts
+++ b/src/api-endpoints/meeting-notes.ts
@@ -1,0 +1,256 @@
+// cspell:disable-file
+// Note: This is a generated file. DO NOT EDIT!
+
+import type {
+  IdResponse,
+  PartialUserObjectResponse,
+  RichTextItemResponse,
+} from "./common"
+
+type QueryMeetingNotesBodyParameters = {
+  // Optional filter for querying meeting notes. Supports combinator (and/or) and property
+  // filters on title, attendees, created_time, created_by, last_edited_time,
+  // last_edited_by.
+  filter?: {
+    // Operator for combinator filters.
+    operator: "and" | "or"
+    // Nested filters; each may be a combinator (and/or) or property filter.
+    filters?: Array<
+      | {
+          // Operator for nested combinator filters.
+          operator: "and" | "or"
+          // Nested filters for combinator filters.
+          filters: Array<
+            | {
+                // Property name.
+                property: string
+                filter: {
+                  // Operator.
+                  operator: string
+                  // Value for the operator.
+                  value?:
+                    | {
+                        type: "relative" | "exact"
+                        value:
+                          | string
+                          | {
+                              type: "date" | "datetime"
+                              start_date: string
+                              start_time?: string
+                              time_zone?: string
+                            }
+                      }
+                    | {
+                        type: "relative" | "exact"
+                        value:
+                          | string
+                          | {
+                              type: "daterange"
+                              start_date: string
+                              end_date?: string
+                            }
+                        direction?: "past" | "future"
+                        unit?: "day" | "week" | "month" | "year"
+                        count?: number
+                      }
+                    | {
+                        type: "exact"
+                        // The text value to filter on.
+                        value: string
+                      }
+                    | Array<{
+                        type: "exact"
+                        value: { table: "notion_user"; id: string }
+                      }>
+                }
+              }
+            | {
+                // Operator for nested combinator filters.
+                operator: "and" | "or"
+                filters: Array<{
+                  // Property name.
+                  property: string
+                  filter: {
+                    // Operator.
+                    operator: string
+                    // Value for the operator.
+                    value?:
+                      | {
+                          type: "relative" | "exact"
+                          value:
+                            | string
+                            | {
+                                type: "date" | "datetime"
+                                start_date: string
+                                start_time?: string
+                                time_zone?: string
+                              }
+                        }
+                      | {
+                          type: "relative" | "exact"
+                          value:
+                            | string
+                            | {
+                                type: "daterange"
+                                start_date: string
+                                end_date?: string
+                              }
+                          direction?: "past" | "future"
+                          unit?: "day" | "week" | "month" | "year"
+                          count?: number
+                        }
+                      | {
+                          type: "exact"
+                          // The text value to filter on.
+                          value: string
+                        }
+                      | Array<{
+                          type: "exact"
+                          value: { table: "notion_user"; id: string }
+                        }>
+                  }
+                }>
+              }
+          >
+        }
+      | {
+          // Property name.
+          property: string
+          filter: {
+            // Operator.
+            operator: string
+            // Value for the operator.
+            value?:
+              | {
+                  type: "relative" | "exact"
+                  value:
+                    | string
+                    | {
+                        type: "date" | "datetime"
+                        start_date: string
+                        start_time?: string
+                        time_zone?: string
+                      }
+                }
+              | {
+                  type: "relative" | "exact"
+                  value:
+                    | string
+                    | {
+                        type: "daterange"
+                        start_date: string
+                        end_date?: string
+                      }
+                  direction?: "past" | "future"
+                  unit?: "day" | "week" | "month" | "year"
+                  count?: number
+                }
+              | {
+                  type: "exact"
+                  // The text value to filter on.
+                  value: string
+                }
+              | Array<{
+                  type: "exact"
+                  value: { table: "notion_user"; id: string }
+                }>
+          }
+        }
+    >
+  }
+  // Optional sort order for the results. Each entry specifies a property name and
+  // direction.
+  sort?: Array<{
+    // Property name to sort by.
+    property:
+      | "title"
+      | "attendees"
+      | "created_time"
+      | "created_by"
+      | "last_edited_time"
+      | "last_edited_by"
+    // Sort direction. Must be 'ascending' or 'descending'.
+    direction: "ascending" | "descending"
+  }>
+  // Maximum number of results to return. Defaults to 50.
+  limit?: number
+}
+
+export type QueryMeetingNotesParameters = QueryMeetingNotesBodyParameters
+
+export type QueryMeetingNotesResponse = {
+  // Meeting note transcription block objects.
+  results: Array<{
+    // Always "block".
+    object: "block"
+    // The ID of the meeting note block.
+    id: IdResponse
+    // Always "meeting_notes".
+    type: "meeting_notes"
+    // Meeting note content fields.
+    meeting_notes: {
+      // Title of the meeting note as rich text.
+      title?: Array<RichTextItemResponse>
+      // Current processing status of the meeting note transcription.
+      status?:
+        | "transcription_not_started"
+        | "transcription_paused"
+        | "transcription_in_progress"
+        | "summary_in_progress"
+        | "notes_ready"
+      // Block IDs for each tab (summary, notes, transcript).
+      children?: {
+        // Block ID of the AI summary tab.
+        summary_block_id?: IdResponse
+        // Block ID of the meeting notes tab.
+        notes_block_id?: IdResponse
+        // Block ID of the transcript tab.
+        transcript_block_id?: IdResponse
+      }
+      // Calendar event metadata associated with this meeting note.
+      calendar_event?: {
+        // ISO-8601 start time of the calendar event.
+        start_time: string
+        // ISO-8601 end time of the calendar event.
+        end_time: string
+        // List of attendee user IDs.
+        attendees?: Array<IdResponse>
+      }
+      // Start and end times of the actual recording.
+      recording?: {
+        // ISO-8601 timestamp when the recording started.
+        start_time?: string
+        // ISO-8601 timestamp when the recording ended.
+        end_time?: string
+      }
+    }
+    // ISO-8601 timestamp when this meeting note was created.
+    created_time: string
+    // ISO-8601 timestamp when this meeting note was last edited.
+    last_edited_time: string
+    // User who created this meeting note.
+    created_by: PartialUserObjectResponse
+    // User who last edited this meeting note.
+    last_edited_by: PartialUserObjectResponse
+    // Whether this block has child blocks.
+    has_children: boolean
+    // Whether this meeting note is in the trash.
+    in_trash: boolean
+    /** @deprecated Use `in_trash` instead. Present for backwards compatibility with API versions prior to 2026-03-11. */
+    archived: boolean
+  }>
+  // Whether additional results exist beyond the returned limit.
+  has_more: boolean
+}
+
+/**
+ * Query meeting notes
+ */
+export const queryMeetingNotes = {
+  method: "post",
+  pathParams: [],
+  queryParams: [],
+  bodyParams: ["filter", "sort", "limit"],
+
+  path: (): string => `blocks/meeting_notes/query`,
+} as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ export type {
   PropertyItemObjectResponse,
   QueryDataSourceParameters,
   QueryDataSourceResponse,
+  QueryMeetingNotesResponse,
   QuoteBlockObjectResponse,
   RelationPropertyItemObjectResponse,
   RichTextItemResponse,
@@ -260,3 +261,12 @@ export {
   extractPageId,
   extractBlockId,
 } from "./helpers"
+export type {
+  QueryMeetingNotesParameters,
+  MeetingNotesCombinatorFilter,
+  MeetingNotesFilterNode,
+  MeetingNotesPropertyFilter,
+  MeetingNotesPropertyName,
+  MeetingNotesSort,
+} from "./meeting-notes"
+export { meetingNotesFilterableProperties } from "./meeting-notes"

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,6 @@ export type {
   PropertyItemObjectResponse,
   QueryDataSourceParameters,
   QueryDataSourceResponse,
-  QueryMeetingNotesResponse,
   QuoteBlockObjectResponse,
   RelationPropertyItemObjectResponse,
   RichTextItemResponse,
@@ -261,6 +260,7 @@ export {
   extractPageId,
   extractBlockId,
 } from "./helpers"
+export type { QueryMeetingNotesResponse } from "./api-endpoints/meeting-notes"
 export type {
   QueryMeetingNotesParameters,
   MeetingNotesCombinatorFilter,

--- a/src/meeting-notes.ts
+++ b/src/meeting-notes.ts
@@ -1,0 +1,180 @@
+import type { QueryMeetingNotesParameters as ApiQueryMeetingNotesParameters } from "./api-endpoints"
+
+// cspell:ignore daterange
+
+export const meetingNotesFilterableProperties = [
+  "title",
+  "created_time",
+  "last_edited_time",
+  "created_by",
+  "last_edited_by",
+  "attendees",
+] as const
+
+const meetingNotesTextFilterOperators = [
+  "string_is",
+  "string_is_not",
+  "string_contains",
+  "string_does_not_contain",
+  "string_starts_with",
+  "string_ends_with",
+  "is_empty",
+  "is_not_empty",
+] as const
+
+const meetingNotesDateFilterOperators = [
+  "date_is",
+  "date_is_before",
+  "date_is_after",
+  "date_is_on_or_before",
+  "date_is_on_or_after",
+  "date_is_within",
+  "date_is_relative_to",
+  "is_empty",
+  "is_not_empty",
+] as const
+
+const meetingNotesPersonFilterOperators = [
+  "person_contains",
+  "person_does_not_contain",
+  "is_empty",
+  "is_not_empty",
+] as const
+
+export type MeetingNotesPropertyName =
+  (typeof meetingNotesFilterableProperties)[number]
+
+type MeetingNotesTextFilterOperator =
+  (typeof meetingNotesTextFilterOperators)[number]
+
+type MeetingNotesDateFilterOperator =
+  (typeof meetingNotesDateFilterOperators)[number]
+
+type MeetingNotesPersonFilterOperator =
+  (typeof meetingNotesPersonFilterOperators)[number]
+
+type MeetingNotesNoValueFilter<TOperator extends string> = {
+  operator: TOperator
+}
+
+type MeetingNotesValueFilter<TOperator extends string, TValue> = {
+  operator: TOperator
+  value: TValue
+}
+
+type MeetingNotesEmptyFilter = MeetingNotesNoValueFilter<
+  "is_empty" | "is_not_empty"
+>
+
+type MeetingNotesTextFilterValue = {
+  type: "exact"
+  value: string
+}
+
+type MeetingNotesDatePointFilterValue = {
+  type: "relative" | "exact"
+  value:
+    | string
+    | {
+        type: "date" | "datetime"
+        start_date: string
+        start_time?: string
+        time_zone?: string
+      }
+}
+
+type MeetingNotesDateRangeFilterValue = {
+  type: "relative" | "exact"
+  value:
+    | string
+    | {
+        type: "daterange"
+        start_date: string
+        end_date?: string
+      }
+  direction?: "past" | "future"
+  unit?: "day" | "week" | "month" | "year"
+  count?: number
+}
+
+type MeetingNotesPersonOperatorValue = {
+  type: "exact"
+  value: {
+    table: "notion_user"
+    id: string
+  }
+}
+
+type MeetingNotesTextFilter =
+  | MeetingNotesValueFilter<
+      Exclude<
+        MeetingNotesTextFilterOperator,
+        MeetingNotesEmptyFilter["operator"]
+      >,
+      MeetingNotesTextFilterValue
+    >
+  | MeetingNotesEmptyFilter
+
+type MeetingNotesDateRangeOperator = "date_is_within" | "date_is_relative_to"
+
+type MeetingNotesDateFilter =
+  | MeetingNotesValueFilter<
+      Exclude<
+        MeetingNotesDateFilterOperator,
+        MeetingNotesDateRangeOperator | MeetingNotesEmptyFilter["operator"]
+      >,
+      MeetingNotesDatePointFilterValue
+    >
+  | MeetingNotesValueFilter<
+      MeetingNotesDateRangeOperator,
+      MeetingNotesDateRangeFilterValue
+    >
+  | MeetingNotesEmptyFilter
+
+type MeetingNotesPersonFilter =
+  | MeetingNotesValueFilter<
+      Exclude<
+        MeetingNotesPersonFilterOperator,
+        MeetingNotesEmptyFilter["operator"]
+      >,
+      MeetingNotesPersonOperatorValue | MeetingNotesPersonOperatorValue[]
+    >
+  | MeetingNotesEmptyFilter
+
+type MeetingNotesPropertyFilterByProperty = {
+  title: MeetingNotesTextFilter
+  created_time: MeetingNotesDateFilter
+  last_edited_time: MeetingNotesDateFilter
+  created_by: MeetingNotesPersonFilter
+  last_edited_by: MeetingNotesPersonFilter
+  attendees: MeetingNotesPersonFilter
+}
+
+export type MeetingNotesPropertyFilter = {
+  [Property in keyof MeetingNotesPropertyFilterByProperty]: {
+    property: Property
+    filter: MeetingNotesPropertyFilterByProperty[Property]
+  }
+}[keyof MeetingNotesPropertyFilterByProperty]
+
+export type MeetingNotesFilterNode =
+  | MeetingNotesCombinatorFilter
+  | MeetingNotesPropertyFilter
+
+export type MeetingNotesCombinatorFilter = {
+  operator: "and" | "or"
+  filters?: MeetingNotesFilterNode[]
+}
+
+export type MeetingNotesSort = {
+  property: MeetingNotesPropertyName
+  direction: "ascending" | "descending"
+}
+
+export type QueryMeetingNotesParameters = Omit<
+  ApiQueryMeetingNotesParameters,
+  "filter" | "sort"
+> & {
+  filter?: MeetingNotesCombinatorFilter
+  sort?: MeetingNotesSort[]
+}

--- a/src/meeting-notes.ts
+++ b/src/meeting-notes.ts
@@ -1,4 +1,4 @@
-import type { QueryMeetingNotesParameters as ApiQueryMeetingNotesParameters } from "./api-endpoints"
+import type { QueryMeetingNotesParameters as ApiQueryMeetingNotesParameters } from "./api-endpoints/meeting-notes"
 
 // cspell:ignore daterange
 

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -21,6 +21,12 @@ describe("Notion SDK Client", () => {
       notion = new Client({ fetch: mockFetch })
     })
 
+    function getFirstRequestBody() {
+      const firstCall = mockFetch.mock.calls[0]
+      const firstCallParams = firstCall?.[1]
+      return JSON.parse(String(firstCallParams?.body) ?? "{}")
+    }
+
     it("calls revoke API with basic auth", async () => {
       await notion.oauth.revoke({
         client_id: "client_id",
@@ -62,11 +68,7 @@ describe("Notion SDK Client", () => {
         })
       )
 
-      const calls = mockFetch.mock.calls
-      const firstCall = calls[0]
-      const firstCallParams = firstCall?.[1]
-      const requestBody = JSON.parse(String(firstCallParams?.body) ?? "{}")
-
+      const requestBody = getFirstRequestBody()
       expect(requestBody).toMatchObject({
         filename: "test.txt",
         content_type: "text/plain",
@@ -97,8 +99,7 @@ describe("Notion SDK Client", () => {
         })
       )
 
-      const calls = mockFetch.mock.calls
-      const firstCall = calls[0]
+      const firstCall = mockFetch.mock.calls[0]
       const firstCallParams = firstCall?.[1]
 
       expect(firstCallParams?.headers).not.toContain("content-type")
@@ -112,6 +113,68 @@ describe("Notion SDK Client", () => {
       assert(typeof formData["file"] === "object")
       assert("size" in formData["file"])
       expect(formData["file"].size).toEqual(4)
+    })
+
+    it("calls query meeting notes API without filter", async () => {
+      await notion.blocks.meetingNotes.query({})
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.notion.com/v1/blocks/meeting_notes/query",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Notion-Version": "2025-09-03",
+            "user-agent": expect.stringContaining("notionhq-client"),
+            "content-type": "application/json",
+          }),
+        })
+      )
+
+      const requestBody = getFirstRequestBody()
+      expect(requestBody).toEqual({})
+    })
+
+    it("calls query meeting notes API with filter", async () => {
+      await notion.blocks.meetingNotes.query({
+        filter: {
+          operator: "and",
+          filters: [
+            {
+              property: "attendees",
+              filter: {
+                operator: "person_contains",
+                value: [
+                  {
+                    type: "exact",
+                    value: {
+                      table: "notion_user",
+                      id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.notion.com/v1/blocks/meeting_notes/query",
+        expect.objectContaining({ method: "POST" })
+      )
+
+      const requestBody = getFirstRequestBody()
+      expect(requestBody).toMatchObject({
+        filter: {
+          operator: "and",
+          filters: [
+            {
+              property: "attendees",
+              filter: { operator: "person_contains" },
+            },
+          ],
+        },
+      })
     })
 
     it("accepts custom request-level headers", async () => {


### PR DESCRIPTION
## Description

Previously, the SDK had no support for querying meeting notes. This change adds `client.blocks.meetingNotes.query()` with strongly-typed filter and sort parameters that use a user-friendly `attendees` property name (matching the server-side alias introduced in the companion notion-next PR).

**Key changes:**

- **Wire up `client.blocks.meetingNotes.query()` in `Client.ts`** — new `meetingNotes` namespace under `blocks` that calls `POST /v1/blocks/meeting_notes/query` with proper body param forwarding for `filter`, `sort`, and `limit`.

- **Add `src/meeting-notes.ts` type overlay** — provides strong SDK-side types for the meeting notes filter DSL. Overrides the generated `QueryMeetingNotesParameters` to use `MeetingNotesCombinatorFilter` (with typed `MeetingNotesFilterNode` and `MeetingNotesPropertyFilter`) and `MeetingNotesSort` instead of the loosely-typed generated params. Property names are typed as a union of `"title" | "created_time" | "last_edited_time" | "created_by" | "last_edited_by" | "attendees"`, and each property type gets its own filter operator/value constraints (text, date, person).

- **Export meeting notes types from `index.ts`** — exports `QueryMeetingNotesParameters`, `MeetingNotesCombinatorFilter`, `MeetingNotesFilterNode`, `MeetingNotesPropertyFilter`, `MeetingNotesPropertyName`, `MeetingNotesSort`, and `meetingNotesFilterableProperties`.

- **Regenerate `api-endpoints.ts`** — updated from the latest OpenAPI spec via `notion public-api update-sdk-js`, adding `QueryMeetingNotesParameters`, `QueryMeetingNotesResponse`, and the `queryMeetingNotes` endpoint descriptor.

- **Add 2 SDK client tests** — `Client.test.ts` tests verify correct URL/method for both no-filter and filter-with-`attendees` payloads, confirming the `attendees` property name flows through correctly in the request body.

## Example queries

**Basic — no filter:**
```ts
const { results } = await client.blocks.meetingNotes.query({});
```

**Title filter** (`string_contains`):
```ts
await client.blocks.meetingNotes.query({
  filter: { operator: "and", filters: [{ property: "title", filter: { operator: "string_contains", value: { type: "exact", value: "standup" } } }] },
});
```

**Date filter** (`created_time` within past 2 weeks):
```ts
await client.blocks.meetingNotes.query({
  filter: { operator: "and", filters: [{ property: "created_time", filter: { operator: "date_is_within", value: { type: "relative", value: "custom", direction: "past", unit: "week", count: 2 } } }] },
});
```

**Attendees filter** (has attendees):
```ts
await client.blocks.meetingNotes.query({
  filter: { operator: "and", filters: [{ property: "attendees", filter: { operator: "is_not_empty" } }] },
});
```

**Complex** (title OR + date range + attendees, with sort + limit):
```ts
await client.blocks.meetingNotes.query({
  filter: {
    operator: "and",
    filters: [
      { operator: "or", filters: [{ property: "title", filter: { operator: "string_contains", value: { type: "exact", value: "planning" } } }, { property: "title", filter: { operator: "string_contains", value: { type: "exact", value: "standup" } } }] },
      { property: "created_time", filter: { operator: "date_is_within", value: { type: "relative", value: "custom", direction: "past", unit: "week", count: 2 } } },
      { property: "attendees", filter: { operator: "is_not_empty" } },
    ],
  },
  sort: [{ property: "created_time", direction: "descending" }],
  limit: 5,
});
```

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

`npm run build && npm test` — 64/64 pass. Manual: `bun index.ts` in `sdk-testing` with linked local SDK exercises base query, title filter, and complex nested query with `attendees` + sort + limit.