### PR TITLE
Sync api-endpoints: add status property support

### DIFF
--- a/src/api-endpoints.ts
+++ b/src/api-endpoints.ts
@@ -3149,10 +3149,29 @@ type StatusDatabasePropertyConfigResponse = {
   }
 }
 
+type StatusPropertyConfigRequest = {
+  // The initial status options. If not provided, defaults are created.
+  options?: Array<{
+    name: string
+    color?: SelectColor
+    description?: string | null
+  }>
+}
+
+type StatusPropertyConfigUpdateRequest = {
+  // Status options to add or update. New options are assigned to the To-do group.
+  options?: Array<
+    { color?: SelectColor; description?: string | null } & (
+      | { name: string; id?: string }
+      | { id: string; name?: string }
+    )
+  >
+}
+
 type StatusPropertyConfigurationRequest = {
   // Always `status`
   type?: "status"
-  status: EmptyObject
+  status: StatusPropertyConfigRequest
 }
 
 type StatusPropertyFilter =
@@ -4679,7 +4698,7 @@ type UpdateDataSourceBodyParameters = {
         | {
             // Always `status`
             type?: "status"
-            status: EmptyObject
+            status: StatusPropertyConfigUpdateRequest
           }
         | {
             // Always `relation`


### PR DESCRIPTION
## Description

This PR syncs `src/api-endpoints.ts` to Notion's latest public [OpenAPI schema](https://developers.notion.com/openapi.json). The specific changes included in this automated regen are:
- Replace `EmptyObject` with 🆕 `StatusPropertyConfigRequest` sub-object in `StatusPropertyConfigurationRequest`
- Replace `EmptyObject` with 🆕 `StatusPropertyConfigUpdateRequest` in `UpdateDataSourceBodyParameters`

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Relying on existing lint and typecheck; minor codegen'd change.

## Screenshots

N/A