### PR TITLE
Add icon support to paragraph block types for tab items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notionhq/client",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notionhq/client",
-      "version": "5.14.0",
+      "version": "5.15.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notionhq/client",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "description": "A simple and easy to use client for the Notion API",
   "engines": {
     "node": ">=18"

--- a/src/api-endpoints/blocks.ts
+++ b/src/api-endpoints/blocks.ts
@@ -532,7 +532,11 @@ export type NumberedListItemBlockObjectResponse = {
 
 export type ParagraphBlockObjectResponse = {
   type: "paragraph"
-  paragraph: ContentWithRichTextAndColorResponse
+  paragraph: {
+    rich_text: Array<RichTextItemResponse>
+    color: ApiColor
+    icon: PageIconResponse | null
+  }
   parent: ParentForBlockBasedObjectResponse
   object: "block"
   id: string
@@ -933,7 +937,11 @@ type UpdateBlockBodyParameters =
       archived?: boolean
     }
   | {
-      paragraph: ContentWithRichTextAndColorRequest
+      paragraph: {
+        rich_text?: Array<RichTextItemRequest>
+        icon?: PageIconRequest
+        color?: ApiColor
+      }
       type?: "paragraph"
       in_trash?: boolean
       /** @deprecated Use `in_trash` instead. */

--- a/src/api-endpoints/common.ts
+++ b/src/api-endpoints/common.ts
@@ -1828,6 +1828,7 @@ export type BlockObjectRequest =
       paragraph: {
         rich_text: Array<RichTextItemRequest>
         color?: ApiColor
+        icon?: PageIconRequest
         children?: Array<BlockObjectWithSingleLevelOfChildrenRequest>
       }
       type?: "paragraph"
@@ -2070,7 +2071,7 @@ type BlockObjectWithSingleLevelOfChildrenRequest =
       object?: "block"
     }
   | {
-      paragraph: ContentWithSingleLevelOfChildrenRequest
+      paragraph: ParagraphWithSingleLevelOfChildrenRequest
       type?: "paragraph"
       object?: "block"
     }
@@ -2541,7 +2542,7 @@ export type BlockObjectRequestWithoutChildren =
       object?: "block"
     }
   | {
-      paragraph: ContentWithRichTextAndColorRequest
+      paragraph: ContentWithRichTextColorAndIconRequest
       type?: "paragraph"
       object?: "block"
     }
@@ -2615,8 +2616,15 @@ type HeaderContentWithSingleLevelOfChildrenRequest = {
   children?: Array<BlockObjectRequestWithoutChildren>
 }
 
+type ParagraphWithSingleLevelOfChildrenRequest = {
+  rich_text: Array<RichTextItemRequest>
+  color?: ApiColor
+  icon?: PageIconRequest
+  children?: Array<BlockObjectRequestWithoutChildren>
+}
+
 type TabItemRequestWithSingleLevelOfChildren = {
-  paragraph: ContentWithSingleLevelOfChildrenRequest
+  paragraph: ParagraphWithSingleLevelOfChildrenRequest
   type?: "paragraph"
   object?: "block"
 }
@@ -2652,6 +2660,12 @@ export type ContentWithRichTextAndColorRequest = {
   color?: ApiColor
 }
 
+type ContentWithRichTextColorAndIconRequest = {
+  rich_text: Array<RichTextItemRequest>
+  color?: ApiColor
+  icon?: PageIconRequest
+}
+
 export type ContentWithRichTextRequest = {
   rich_text: Array<RichTextItemRequest>
 }
@@ -2663,7 +2677,7 @@ export type HeaderContentWithRichTextAndColorRequest = {
 }
 
 type TabItemRequestWithoutChildren = {
-  paragraph: ContentWithRichTextAndColorRequest
+  paragraph: ContentWithRichTextColorAndIconRequest
   type?: "paragraph"
   object?: "block"
 }


### PR DESCRIPTION
## Description

Generated via `notion public-api update-sdk-js` from notion-next [PR #198748](https://github.com/makenotion/notion-next/pull/198748).

Adds optional `icon` field to paragraph block request and response types, enabling icon support on tab items (paragraph children of tab blocks). Matches the existing callout block icon pattern. The API validates that icon can only be set on paragraphs that are direct children of a tab block.

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Verified generated types match the updated OpenAPI spec. Server-side validation and integration tests are in the linked notion-next PR.

## Screenshots