### PR TITLE
Update SDK types: H4 blocks; view API property encoding; "me" person filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ You may also set a custom `logger` to emit logs to a destination other than `std
 
 The `Client` supports the following options on initialization. These options are all keys in the single constructor parameter.
 
-| Option      | Default value              | Type           | Description                                                                                                                                                  |
-| ----------- | -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `auth`      | `undefined`                | `string`       | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request.                                                      |
-| `logLevel`  | `LogLevel.WARN`            | `LogLevel`     | Verbosity of logs the instance will produce. By default, logs are written to `stdout`.                                                                       |
-| `timeoutMs` | `60_000`                   | `number`       | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                                       |
-| `baseUrl`   | `"https://api.notion.com"` | `string`       | The root URL for sending API requests. This can be changed to test with a mock server.                                                                       |
-| `logger`    | Log to console             | `Logger`       | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`.                       |
-| `agent`     | Default node agent         | `http.Agent`   | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent) |
-| `retry`     | `{ maxRetries: 2 }`        | `RetryOptions` | Configuration for automatic retries on rate limits (429) and server errors (500, 503). See [Automatic retries](#automatic-retries) below.                    |
+| Option      | Default value               | Type           | Description                                                                                                                                                  |
+| ----------- | --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `auth`      | `undefined`                 | `string`       | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request.                                                      |
+| `logLevel`  | `LogLevel.WARN`             | `LogLevel`     | Verbosity of logs the instance will produce. By default, logs are written to `stdout`.                                                                       |
+| `timeoutMs` | `DEFAULT_TIMEOUT_MS`        | `number`       | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                                       |
+| `baseUrl`   | `DEFAULT_BASE_URL`          | `string`       | The root URL for sending API requests. This can be changed to test with a mock server.                                                                       |
+| `logger`    | Log to console              | `Logger`       | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`.                       |
+| `agent`     | Default node agent          | `http.Agent`   | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent) |
+| `retry`     | See [constants](#constants) | `RetryOptions` | Configuration for automatic retries on rate limits (429) and server errors (500, 503). See [Automatic retries](#automatic-retries) below.                    |
 
 ### Automatic retries
 
@@ -181,6 +181,42 @@ To disable automatic retries:
 const notion = new Client({
   auth: process.env.NOTION_TOKEN,
   retry: false,
+})
+```
+
+### Constants
+
+The SDK exports named constants for all default values used by the client, as well as useful Notion-specific values. You can import them directly:
+
+```js
+const {
+  DEFAULT_BASE_URL, // "https://api.notion.com"
+  DEFAULT_TIMEOUT_MS, // 60_000
+  DEFAULT_MAX_RETRIES, // 2
+  DEFAULT_INITIAL_RETRY_DELAY_MS, // 1_000
+  DEFAULT_MAX_RETRY_DELAY_MS, // 60_000
+  MIN_VIEW_COLUMN_WIDTH, // 32
+} = require("@notionhq/client")
+```
+
+`MIN_VIEW_COLUMN_WIDTH` is the minimum width (in pixels) that a table column can have in the Notion UI. Set a property's `width` to this value when creating or updating a view to make a column appear collapsed -- useful for checkbox or status-as-checkbox columns:
+
+```js
+await notion.views.create({
+  database_id: databaseId,
+  name: "My view",
+  type: "table",
+  configuration: {
+    table: {
+      properties: [
+        {
+          property_id: checkboxPropId,
+          visible: true,
+          width: MIN_VIEW_COLUMN_WIDTH,
+        },
+      ],
+    },
+  },
 })
 ```
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -17,6 +17,13 @@ import {
 } from "./errors"
 import { pick, getUnknownParams, type EndpointDefinition } from "./utils"
 import {
+  DEFAULT_BASE_URL,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_INITIAL_RETRY_DELAY_MS,
+  DEFAULT_MAX_RETRY_DELAY_MS,
+} from "./constants"
+import {
   type GetBlockParameters,
   type GetBlockResponse,
   getBlock,
@@ -237,8 +244,8 @@ export default class Client {
     this.#auth = options?.auth
     this.#logLevel = options?.logLevel ?? LogLevel.WARN
     this.#logger = options?.logger ?? makeConsoleLogger(PACKAGE_NAME)
-    this.#prefixUrl = `${options?.baseUrl ?? "https://api.notion.com"}/v1/`
-    this.#timeoutMs = options?.timeoutMs ?? 60_000
+    this.#prefixUrl = `${options?.baseUrl ?? DEFAULT_BASE_URL}/v1/`
+    this.#timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS
     this.#notionVersion = options?.notionVersion ?? Client.defaultNotionVersion
     this.#fetch = options?.fetch ?? fetch.bind(globalThis)
     this.#agent = options?.agent
@@ -249,9 +256,11 @@ export default class Client {
       this.#initialRetryDelayMs = 0
       this.#maxRetryDelayMs = 0
     } else {
-      this.#maxRetries = options?.retry?.maxRetries ?? 2
-      this.#initialRetryDelayMs = options?.retry?.initialRetryDelayMs ?? 1000
-      this.#maxRetryDelayMs = options?.retry?.maxRetryDelayMs ?? 60_000
+      this.#maxRetries = options?.retry?.maxRetries ?? DEFAULT_MAX_RETRIES
+      this.#initialRetryDelayMs =
+        options?.retry?.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS
+      this.#maxRetryDelayMs =
+        options?.retry?.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS
     }
   }
 

--- a/src/api-endpoints/blocks.ts
+++ b/src/api-endpoints/blocks.ts
@@ -55,6 +55,7 @@ export type BlockObjectResponse =
   | Heading1BlockObjectResponse
   | Heading2BlockObjectResponse
   | Heading3BlockObjectResponse
+  | Heading4BlockObjectResponse
   | BulletedListItemBlockObjectResponse
   | NumberedListItemBlockObjectResponse
   | QuoteBlockObjectResponse
@@ -405,6 +406,22 @@ export type Heading2BlockObjectResponse = {
 export type Heading3BlockObjectResponse = {
   type: "heading_3"
   heading_3: HeaderContentWithRichTextAndColorResponse
+  parent: ParentForBlockBasedObjectResponse
+  object: "block"
+  id: string
+  created_time: string
+  created_by: PartialUserObjectResponse
+  last_edited_time: string
+  last_edited_by: PartialUserObjectResponse
+  has_children: boolean
+  in_trash: boolean
+  /** @deprecated Use `in_trash` instead. Present for backwards compatibility with API versions prior to 2026-03-11. */
+  archived: boolean
+}
+
+export type Heading4BlockObjectResponse = {
+  type: "heading_4"
+  heading_4: HeaderContentWithRichTextAndColorResponse
   parent: ParentForBlockBasedObjectResponse
   object: "block"
   id: string
@@ -940,6 +957,13 @@ type UpdateBlockBodyParameters =
       archived?: boolean
     }
   | {
+      heading_4: HeaderContentWithRichTextAndColorRequest
+      type?: "heading_4"
+      in_trash?: boolean
+      /** @deprecated Use `in_trash` instead. */
+      archived?: boolean
+    }
+  | {
       paragraph: ContentWithRichTextColorAndIconUpdateRequest
       type?: "paragraph"
       in_trash?: boolean
@@ -1072,6 +1096,7 @@ export const updateBlock = {
     "heading_1",
     "heading_2",
     "heading_3",
+    "heading_4",
     "paragraph",
     "bulleted_list_item",
     "numbered_list_item",

--- a/src/api-endpoints/common.ts
+++ b/src/api-endpoints/common.ts
@@ -1014,8 +1014,8 @@ type PeoplePropertyConfigurationRequest = {
 }
 
 type PeoplePropertyFilter =
-  | { contains: IdRequest }
-  | { does_not_contain: IdRequest }
+  | { contains: PersonIdOrMe }
+  | { does_not_contain: PersonIdOrMe }
   | ExistencePropertyFilter
 
 type PersonGroupByConfigRequest = {
@@ -1028,6 +1028,8 @@ type PersonGroupByConfigRequest = {
   // Whether to hide groups that have no items.
   hide_empty_groups?: boolean
 }
+
+type PersonIdOrMe = IdRequest | "me"
 
 export type PersonUserObjectResponse = {
   // Indicates this user is a person.
@@ -1831,6 +1833,16 @@ export type BlockObjectRequest =
       object?: "block"
     }
   | {
+      heading_4: {
+        rich_text: Array<RichTextItemRequest>
+        color?: ApiColor
+        is_toggleable?: boolean
+        children?: Array<BlockObjectWithSingleLevelOfChildrenRequest>
+      }
+      type?: "heading_4"
+      object?: "block"
+    }
+  | {
       paragraph: {
         rich_text: Array<RichTextItemRequest>
         color?: ApiColor
@@ -2074,6 +2086,11 @@ type BlockObjectWithSingleLevelOfChildrenRequest =
   | {
       heading_3: HeaderContentWithSingleLevelOfChildrenRequest
       type?: "heading_3"
+      object?: "block"
+    }
+  | {
+      heading_4: HeaderContentWithSingleLevelOfChildrenRequest
+      type?: "heading_4"
       object?: "block"
     }
   | {
@@ -2545,6 +2562,11 @@ export type BlockObjectRequestWithoutChildren =
   | {
       heading_3: HeaderContentWithRichTextAndColorRequest
       type?: "heading_3"
+      object?: "block"
+    }
+  | {
+      heading_4: HeaderContentWithRichTextAndColorRequest
+      type?: "heading_4"
       object?: "block"
     }
   | {

--- a/src/api-endpoints/common.ts
+++ b/src/api-endpoints/common.ts
@@ -430,6 +430,8 @@ type DateGroupByConfigRequest = {
   start_day_of_week?: 0 | 1
 }
 
+type DateOrRelativeDate = string | RelativeDateValue
+
 type DatePropertyConfigurationRequest = {
   // Always `date`
   type?: "date"
@@ -437,11 +439,11 @@ type DatePropertyConfigurationRequest = {
 }
 
 type DatePropertyFilter =
-  | { equals: string }
-  | { before: string }
-  | { after: string }
-  | { on_or_before: string }
-  | { on_or_after: string }
+  | { equals: DateOrRelativeDate }
+  | { before: DateOrRelativeDate }
+  | { after: DateOrRelativeDate }
+  | { on_or_before: DateOrRelativeDate }
+  | { on_or_after: DateOrRelativeDate }
   | { this_week: EmptyObject }
   | { past_week: EmptyObject }
   | { past_month: EmptyObject }
@@ -1182,6 +1184,15 @@ type RelationPropertyFilter =
   | { contains: IdRequest }
   | { does_not_contain: IdRequest }
   | ExistencePropertyFilter
+
+type RelativeDateValue =
+  | "today"
+  | "tomorrow"
+  | "yesterday"
+  | "one_week_ago"
+  | "one_week_from_now"
+  | "one_month_ago"
+  | "one_month_from_now"
 
 export type RichTextItemResponse = RichTextItemResponseCommon &
   (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,36 @@
+/**
+ * Default base URL for the Notion API.
+ */
+export const DEFAULT_BASE_URL = "https://api.notion.com"
+
+/**
+ * Default request timeout in milliseconds (60 seconds).
+ */
+export const DEFAULT_TIMEOUT_MS = 60_000
+
+/**
+ * Default maximum number of retry attempts for failed requests.
+ */
+export const DEFAULT_MAX_RETRIES = 2
+
+/**
+ * Default initial delay between retries in milliseconds (1 second).
+ * Used as the base for exponential back-off when the retry-after
+ * header is absent.
+ */
+export const DEFAULT_INITIAL_RETRY_DELAY_MS = 1_000
+
+/**
+ * Default maximum delay between retries in milliseconds
+ * (60 seconds). Caps both retry-after and exponential
+ * back-off delays.
+ */
+export const DEFAULT_MAX_RETRY_DELAY_MS = 60_000
+
+/**
+ * The minimum width of a view column in pixels. Use this
+ * with the views API to make a property column that appears
+ * minimal / collapsed in the Notion app UI (e.g. a checkbox
+ * or status-as-checkbox column).
+ */
+export const MIN_VIEW_COLUMN_WIDTH = 32

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,14 @@ export {
 } from "./errors"
 export type { RetryOptions } from "./Client"
 export {
+  DEFAULT_BASE_URL,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_INITIAL_RETRY_DELAY_MS,
+  DEFAULT_MAX_RETRY_DELAY_MS,
+  MIN_VIEW_COLUMN_WIDTH,
+} from "./constants"
+export {
   collectPaginatedAPI,
   iteratePaginatedAPI,
   collectDataSourceTemplates,


### PR DESCRIPTION
## Description

Companion PR to recent Notion API changes, plus new exported constants for SDK users.

### API type updates (`src/api-endpoints/`)

- **`"me"` person filters**: `PeoplePropertyFilter.contains` and `does_not_contain` now accept `"me"` in addition to a UUID, enabling person filters for the current user.
  - New type: `PersonIdOrMe` (`IdRequest | "me"`)
- **Relative date filters**: `DatePropertyFilter` operators (`equals`, `before`, `after`, `on_or_before`, `on_or_after`) now accept relative date keywords in addition to date strings.
  - New type: `RelativeDateValue` (`"today" | "tomorrow" | "yesterday" | "one_week_ago" | ...`)
  - New type: `DateOrRelativeDate` (`string | RelativeDateValue`)
- **`heading_4` blocks**: new `Heading4BlockObjectResponse` type.

### Exported constants (`src/constants.ts`)

Adds a new `src/constants.ts` module that centralizes magic numbers previously scattered through `Client.ts`. All constants are exported from the SDK's public interface (`src/index.ts`):

- `DEFAULT_BASE_URL` — `"https://api.notion.com"`
- `DEFAULT_TIMEOUT_MS` — `60_000`
- `DEFAULT_MAX_RETRIES` — `2`
- `DEFAULT_INITIAL_RETRY_DELAY_MS` — `1_000`
- `DEFAULT_MAX_RETRY_DELAY_MS` — `60_000`
- `MIN_VIEW_COLUMN_WIDTH` — `32` (minimum table column width in pixels; useful for making checkbox/status columns appear collapsed via the views API)

`Client.ts` now imports these constants instead of using inline literals. README updated with a new "Constants" section documenting all exported values, including a usage example for `MIN_VIEW_COLUMN_WIDTH`.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

All existing tests pass. The constants change is a pure refactor of default values already covered by the existing Client test suite.

## Screenshots

N/A