### PR TITLE
Introduce helpers for webhook signature verification

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -15,7 +15,8 @@
     "printf",
     "is_toggleable",
     "typecheck",
-    "retryable"
+    "retryable",
+    "HMAC"
   ],
   // flagWords - list of words to be always considered incorrect
   // This is useful for offensive words and common spelling errors.

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ The same helper handles the initial verification handshake that Notion sends whe
 `signWebhookPayload({ body, verificationToken })` produces the same `sha256=<hex>` header value, which is useful for unit-testing your webhook handler without standing up a real subscription.
 
 > [!NOTE]
-> Both helpers are async (they use the Web Crypto API) so they run in Node.js, edge runtimes such as Vercel Edge Functions and Cloudflare Workers, and Deno without depending on `node:crypto`.
+> Both helpers are async. They prefer the Web Crypto API (`globalThis.crypto.subtle`) when present and transparently fall back to `node:crypto` on older Node.js 18 builds, so they run unchanged on Node.js, Bun, Deno, Vercel Edge Functions, Cloudflare Workers, and modern browsers.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,43 @@ The `notion.request<ResponseBody>({...})` method is generic; `ResponseBody` repr
 
 Another customization you can make is to pass your own `fetch` function to the `Client` constructor. This might be helpful for some execution environments where the default, built-in `fetch` isn't suitable.
 
+### Verifying webhook signatures
+
+If your integration receives [Notion webhook deliveries](https://developers.notion.com/reference/webhooks), use `verifyWebhookSignature` to confirm each request was sent by Notion and was not tampered with in transit. Notion signs every delivery with HMAC-SHA256 over the raw request body using the subscription's verification token, and places the result in the `X-Notion-Signature` header as `sha256=<hex>`.
+
+```ts
+import { verifyWebhookSignature } from "@notionhq/client"
+
+// Express example. The body must be read as the raw text/bytes that
+// arrived over the wire — JSON-parsed and re-serialized bodies will not
+// verify, because re-serialization changes whitespace and key order.
+app.post(
+  "/notion-webhook",
+  express.text({ type: "application/json" }),
+  async (req, res) => {
+    const ok = await verifyWebhookSignature({
+      body: req.body,
+      signature: req.header("x-notion-signature"),
+      verificationToken: process.env.NOTION_WEBHOOK_VERIFICATION_TOKEN!,
+    })
+    if (!ok) {
+      return res.status(401).send("invalid signature")
+    }
+
+    const event = JSON.parse(req.body)
+    // …handle the event
+    res.status(200).send("ok")
+  }
+)
+```
+
+The same helper handles the initial verification handshake that Notion sends when you first register a webhook URL — the handshake body (`{ "verification_token": "..." }`) is signed with the same token, so a single code path covers both cases.
+
+`signWebhookPayload({ body, verificationToken })` produces the same `sha256=<hex>` header value, which is useful for unit-testing your webhook handler without standing up a real subscription.
+
+> [!NOTE]
+> Both helpers are async (they use the Web Crypto API) so they run in Node.js, edge runtimes such as Vercel Edge Functions and Cloudflare Workers, and Deno without depending on `node:crypto`.
+
 ## Examples
 
 For sample code and example projects, see [notion-cookbook](https://github.com/makenotion/notion-cookbook/tree/main/examples).

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,6 +260,8 @@ export {
   extractPageId,
   extractBlockId,
 } from "./helpers"
+export { verifyWebhookSignature, signWebhookPayload } from "./webhooks"
+export type { VerifyWebhookSignatureArgs } from "./webhooks"
 export type { QueryMeetingNotesResponse } from "./api-endpoints/meeting-notes"
 export type {
   QueryMeetingNotesParameters,

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,16 +1,19 @@
 /**
  * Helpers for receiving and verifying Notion webhook deliveries.
  *
- * Notion signs each webhook request with HMAC-SHA256 over the raw HTTP body
- * using the subscription's verification token as the key, and sends the
- * resulting hex digest in the `X-Notion-Signature` header as
+ * Notion signs each webhook request with HMAC-SHA256 over the raw HTTP
+ * body using the subscription's verification token as the key, and sends
+ * the resulting hex digest in the `X-Notion-Signature` header as
  * `sha256=<hex>`. To verify a delivery, callers must pass the body
- * **exactly as it arrived over the wire** — any JSON re-serialization will
- * change the bytes and invalidate the signature.
+ * **exactly as it arrived over the wire** — any JSON re-serialization
+ * will change the bytes and invalidate the signature.
  *
- * These helpers use the Web Crypto API (`globalThis.crypto.subtle`) so they
- * work in Node.js (>= 18), edge runtimes (Vercel, Cloudflare Workers, Deno),
- * and modern browsers without depending on `node:crypto`.
+ * The helpers prefer the Web Crypto API (`globalThis.crypto.subtle`)
+ * when present (browsers, edge runtimes, Node.js >= 18.19) and
+ * transparently fall back to `node:crypto`'s `webcrypto.subtle` on older
+ * Node.js 18 builds where `globalThis.crypto` is not yet enabled by
+ * default. They work without configuration in Node.js, Bun, Deno,
+ * Vercel Edge Functions, Cloudflare Workers, and modern browsers.
  */
 
 const SIGNATURE_PREFIX = "sha256="
@@ -40,10 +43,10 @@ export type VerifyWebhookSignatureArgs = {
  * Verify that a webhook delivery came from Notion and has not been
  * tampered with.
  *
- * Performs a constant-time comparison; returns `true` only if the supplied
- * `signature` matches HMAC-SHA256 of `body` keyed by `verificationToken`.
- * Returns `false` (rather than throwing) for any malformed input so the
- * caller can respond with a single 401/403 path.
+ * Performs a constant-time comparison; returns `true` only if the
+ * supplied `signature` matches HMAC-SHA256 of `body` keyed by
+ * `verificationToken`. Returns `false` (rather than throwing) for any
+ * malformed input so the caller can respond with a single 401/403 path.
  */
 export async function verifyWebhookSignature(
   args: VerifyWebhookSignatureArgs
@@ -62,9 +65,9 @@ export async function verifyWebhookSignature(
 }
 
 /**
- * Compute the value Notion would send in `X-Notion-Signature` for a given
- * body and verification token. Useful for unit-testing webhook handlers
- * without standing up a real subscription.
+ * Compute the value Notion would send in `X-Notion-Signature` for a
+ * given body and verification token. Useful for unit-testing webhook
+ * handlers without standing up a real subscription.
  */
 export async function signWebhookPayload(args: {
   body: string | Uint8Array
@@ -78,22 +81,13 @@ async function computeHmacSha256Hex(
   key: string,
   body: string | Uint8Array
 ): Promise<string> {
-  const subtle = globalThis.crypto?.subtle
-  if (!subtle) {
-    // Web Crypto is present on Node >= 15 and all supported runtimes; if a
-    // host strips it, fail loudly rather than silently weakening security.
-    throw new Error(
-      "verifyWebhookSignature requires Web Crypto support " +
-        "(globalThis.crypto.subtle). Upgrade to Node.js 18+ or a runtime " +
-        "that provides Web Crypto."
-    )
-  }
+  const subtle = await getSubtle()
 
   const encoder = new TextEncoder()
   const keyBytes = encoder.encode(key)
-  // Copy any Uint8Array input into a fresh ArrayBuffer-backed view so the
-  // subtle.sign signature (which forbids SharedArrayBuffer-backed views)
-  // is satisfied regardless of the caller's buffer source (e.g. Node Buffer).
+  // Copy any Uint8Array input into a fresh ArrayBuffer-backed view so
+  // subtle.sign (which forbids SharedArrayBuffer-backed views) is
+  // satisfied regardless of where the caller's buffer came from.
   const bodyBytes =
     typeof body === "string" ? encoder.encode(body) : Uint8Array.from(body)
 
@@ -108,6 +102,49 @@ async function computeHmacSha256Hex(
   return bytesToHex(new Uint8Array(signatureBuffer))
 }
 
+let cachedSubtle: SubtleCrypto | undefined
+
+async function getSubtle(): Promise<SubtleCrypto> {
+  if (cachedSubtle) return cachedSubtle
+
+  // Preferred path: every modern runtime exposes Web Crypto on the
+  // global object. This includes browsers, Vercel Edge, Cloudflare
+  // Workers, Deno, Bun, and Node.js >= 18.19 (which backported the
+  // change from Node.js 19).
+  const fromGlobal = (globalThis as { crypto?: { subtle?: SubtleCrypto } })
+    .crypto?.subtle
+  if (fromGlobal) {
+    cachedSubtle = fromGlobal
+    return cachedSubtle
+  }
+
+  // Fallback for Node.js 18.0–18.18, which ships Web Crypto via
+  // `node:crypto` but does not expose it on `globalThis` by default.
+  // Using `require` (rather than a static `import`) keeps the
+  // node:crypto reference off the dependency graph of browser bundlers
+  // that would otherwise fail to resolve it.
+  try {
+    /* eslint-disable @typescript-eslint/no-var-requires */
+    const nodeCrypto = require("crypto") as {
+      webcrypto?: { subtle?: SubtleCrypto }
+    }
+    /* eslint-enable @typescript-eslint/no-var-requires */
+    if (nodeCrypto.webcrypto?.subtle) {
+      cachedSubtle = nodeCrypto.webcrypto.subtle
+      return cachedSubtle
+    }
+  } catch {
+    // node:crypto unavailable (e.g. a browser bundle that stubbed it).
+    // Fall through to the error below.
+  }
+
+  throw new Error(
+    "verifyWebhookSignature requires Web Crypto support " +
+      "(globalThis.crypto.subtle or node:crypto.webcrypto). Upgrade to " +
+      "a runtime that provides one of them."
+  )
+}
+
 function bytesToHex(bytes: Uint8Array): string {
   let hex = ""
   for (let i = 0; i < bytes.length; i++) {
@@ -116,7 +153,7 @@ function bytesToHex(bytes: Uint8Array): string {
   return hex
 }
 
-// Constant-time string comparison. The two inputs are already known to be
+// Constant-time string comparison. The inputs are already known to be
 // the same length (callers enforce SHA256_HEX_LENGTH), so this purely
 // avoids early-exit on the first differing character.
 function timingSafeEqualHex(a: string, b: string): boolean {

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -1,0 +1,129 @@
+/**
+ * Helpers for receiving and verifying Notion webhook deliveries.
+ *
+ * Notion signs each webhook request with HMAC-SHA256 over the raw HTTP body
+ * using the subscription's verification token as the key, and sends the
+ * resulting hex digest in the `X-Notion-Signature` header as
+ * `sha256=<hex>`. To verify a delivery, callers must pass the body
+ * **exactly as it arrived over the wire** — any JSON re-serialization will
+ * change the bytes and invalidate the signature.
+ *
+ * These helpers use the Web Crypto API (`globalThis.crypto.subtle`) so they
+ * work in Node.js (>= 18), edge runtimes (Vercel, Cloudflare Workers, Deno),
+ * and modern browsers without depending on `node:crypto`.
+ */
+
+const SIGNATURE_PREFIX = "sha256="
+const SHA256_HEX_LENGTH = 64
+
+export type VerifyWebhookSignatureArgs = {
+  /**
+   * The raw HTTP request body — exactly as received, before any parsing.
+   * Pass a string for text bodies or a Uint8Array/Buffer for binary-safe
+   * access. Re-serialized JSON will not verify.
+   */
+  body: string | Uint8Array
+  /**
+   * The value of the `X-Notion-Signature` request header. Verification
+   * fails (returns false) if this is missing or malformed.
+   */
+  signature: string | null | undefined
+  /**
+   * The verification token configured for this webhook subscription
+   * (returned by Notion when the subscription was created and surfaced
+   * during the initial handshake).
+   */
+  verificationToken: string
+}
+
+/**
+ * Verify that a webhook delivery came from Notion and has not been
+ * tampered with.
+ *
+ * Performs a constant-time comparison; returns `true` only if the supplied
+ * `signature` matches HMAC-SHA256 of `body` keyed by `verificationToken`.
+ * Returns `false` (rather than throwing) for any malformed input so the
+ * caller can respond with a single 401/403 path.
+ */
+export async function verifyWebhookSignature(
+  args: VerifyWebhookSignatureArgs
+): Promise<boolean> {
+  const { body, signature, verificationToken } = args
+
+  if (typeof signature !== "string") return false
+  if (!signature.startsWith(SIGNATURE_PREFIX)) return false
+
+  const providedHex = signature.slice(SIGNATURE_PREFIX.length).toLowerCase()
+  if (providedHex.length !== SHA256_HEX_LENGTH) return false
+  if (!/^[0-9a-f]+$/.test(providedHex)) return false
+
+  const computedHex = await computeHmacSha256Hex(verificationToken, body)
+  return timingSafeEqualHex(providedHex, computedHex)
+}
+
+/**
+ * Compute the value Notion would send in `X-Notion-Signature` for a given
+ * body and verification token. Useful for unit-testing webhook handlers
+ * without standing up a real subscription.
+ */
+export async function signWebhookPayload(args: {
+  body: string | Uint8Array
+  verificationToken: string
+}): Promise<string> {
+  const hex = await computeHmacSha256Hex(args.verificationToken, args.body)
+  return `${SIGNATURE_PREFIX}${hex}`
+}
+
+async function computeHmacSha256Hex(
+  key: string,
+  body: string | Uint8Array
+): Promise<string> {
+  const subtle = globalThis.crypto?.subtle
+  if (!subtle) {
+    // Web Crypto is present on Node >= 15 and all supported runtimes; if a
+    // host strips it, fail loudly rather than silently weakening security.
+    throw new Error(
+      "verifyWebhookSignature requires Web Crypto support " +
+        "(globalThis.crypto.subtle). Upgrade to Node.js 18+ or a runtime " +
+        "that provides Web Crypto."
+    )
+  }
+
+  const encoder = new TextEncoder()
+  const keyBytes = encoder.encode(key)
+  // Copy any Uint8Array input into a fresh ArrayBuffer-backed view so the
+  // subtle.sign signature (which forbids SharedArrayBuffer-backed views)
+  // is satisfied regardless of the caller's buffer source (e.g. Node Buffer).
+  const bodyBytes =
+    typeof body === "string" ? encoder.encode(body) : Uint8Array.from(body)
+
+  const cryptoKey = await subtle.importKey(
+    "raw",
+    keyBytes,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  )
+  const signatureBuffer = await subtle.sign("HMAC", cryptoKey, bodyBytes)
+  return bytesToHex(new Uint8Array(signatureBuffer))
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = ""
+  for (let i = 0; i < bytes.length; i++) {
+    hex += (bytes[i] as number).toString(16).padStart(2, "0")
+  }
+  return hex
+}
+
+// Constant-time string comparison. The two inputs are already known to be
+// the same length (callers enforce SHA256_HEX_LENGTH), so this purely
+// avoids early-exit on the first differing character.
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -1,0 +1,201 @@
+import { createHmac } from "crypto"
+import { verifyWebhookSignature, signWebhookPayload } from "../src/webhooks"
+
+const VERIFICATION_TOKEN = "secret_abc123_verification_token"
+const ALTERNATE_TOKEN = "secret_different_token_xyz"
+
+function nodeSign(body: string | Uint8Array, token: string): string {
+  const hmac = createHmac("sha256", token)
+  hmac.update(body)
+  return `sha256=${hmac.digest("hex")}`
+}
+
+describe("verifyWebhookSignature", () => {
+  it("returns true for a valid signature over a string body", async () => {
+    const body = JSON.stringify({ id: "evt_1", type: "page.created" })
+    const signature = nodeSign(body, VERIFICATION_TOKEN)
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it("returns true for a valid signature over a Uint8Array body", async () => {
+    const bodyString = JSON.stringify({ id: "evt_1", type: "page.created" })
+    const body = new TextEncoder().encode(bodyString)
+    const signature = nodeSign(bodyString, VERIFICATION_TOKEN)
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it("returns false when the body has been tampered with", async () => {
+    const original = JSON.stringify({ id: "evt_1", type: "page.created" })
+    const tampered = JSON.stringify({ id: "evt_1", type: "page.deleted" })
+    const signature = nodeSign(original, VERIFICATION_TOKEN)
+
+    await expect(
+      verifyWebhookSignature({
+        body: tampered,
+        signature,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it("returns false when the verification token is wrong", async () => {
+    const body = JSON.stringify({ id: "evt_1" })
+    const signature = nodeSign(body, VERIFICATION_TOKEN)
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature,
+        verificationToken: ALTERNATE_TOKEN,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it("returns false when the signature header is missing", async () => {
+    const body = JSON.stringify({ id: "evt_1" })
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature: undefined,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(false)
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature: null,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it("returns false when the signature header lacks the sha256= prefix", async () => {
+    const body = JSON.stringify({ id: "evt_1" })
+    const fullSig = nodeSign(body, VERIFICATION_TOKEN)
+    const hexOnly = fullSig.slice("sha256=".length)
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature: hexOnly,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it("returns false for malformed hex in the signature", async () => {
+    const body = JSON.stringify({ id: "evt_1" })
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature: "sha256=not-hex-content-here",
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it("returns false when the hex digest length is wrong", async () => {
+    const body = JSON.stringify({ id: "evt_1" })
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature: "sha256=abcdef",
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(false)
+  })
+
+  it("accepts uppercase hex digits in the signature header", async () => {
+    const body = JSON.stringify({ id: "evt_1" })
+    const lower = nodeSign(body, VERIFICATION_TOKEN)
+    const upper = `sha256=${lower.slice("sha256=".length).toUpperCase()}`
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature: upper,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it("verifies the initial verification_token handshake payload", async () => {
+    // When a webhook is first set up, Notion POSTs `{ verification_token }`
+    // signed with that same token. The helper must handle this case
+    // identically to any subsequent event delivery.
+    const body = JSON.stringify({ verification_token: VERIFICATION_TOKEN })
+    const signature = nodeSign(body, VERIFICATION_TOKEN)
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it("matches the algorithm used by the Notion webhook delivery pipeline", async () => {
+    // Locked-down fixture: ensure interop with the canonical algorithm
+    // (HMAC-SHA256 over raw body bytes, hex digest, "sha256=" prefix).
+    const body = '{"id":"fixed-evt","type":"page.created"}'
+    const token = "fixed-verification-token"
+    const expected =
+      "sha256=" + createHmac("sha256", token).update(body).digest("hex")
+
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature: expected,
+        verificationToken: token,
+      })
+    ).resolves.toBe(true)
+  })
+})
+
+describe("signWebhookPayload", () => {
+  it("produces a signature accepted by verifyWebhookSignature", async () => {
+    const body = JSON.stringify({ id: "evt_1", type: "page.created" })
+    const signature = await signWebhookPayload({
+      body,
+      verificationToken: VERIFICATION_TOKEN,
+    })
+
+    expect(signature.startsWith("sha256=")).toBe(true)
+    await expect(
+      verifyWebhookSignature({
+        body,
+        signature,
+        verificationToken: VERIFICATION_TOKEN,
+      })
+    ).resolves.toBe(true)
+  })
+
+  it("agrees byte-for-byte with the node:crypto reference", async () => {
+    const body = JSON.stringify({ hello: "world" })
+    const expected = nodeSign(body, VERIFICATION_TOKEN)
+    const actual = await signWebhookPayload({
+      body,
+      verificationToken: VERIFICATION_TOKEN,
+    })
+    expect(actual).toBe(expected)
+  })
+})

--- a/test/webhooks.test.ts
+++ b/test/webhooks.test.ts
@@ -199,3 +199,35 @@ describe("signWebhookPayload", () => {
     expect(actual).toBe(expected)
   })
 })
+
+describe("verifyWebhookSignature: fallback to node:crypto", () => {
+  // Exercises the path used on Node.js 18.0–18.18, where `globalThis.crypto`
+  // is not enabled by default. We can't downgrade the test runner, so we
+  // simulate the missing global and re-import the module fresh so its
+  // `cachedSubtle` is empty.
+  const originalGlobalCrypto = (globalThis as { crypto?: unknown }).crypto
+
+  afterEach(() => {
+    const g = globalThis as { crypto?: unknown }
+    g.crypto = originalGlobalCrypto
+    jest.resetModules()
+  })
+
+  it("verifies a real signature using node:crypto webcrypto when globalThis.crypto is missing", async () => {
+    delete (globalThis as { crypto?: unknown }).crypto
+
+    let verify: typeof verifyWebhookSignature | undefined
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      verify = require("../src/webhooks").verifyWebhookSignature
+    })
+    if (!verify) throw new Error("module did not load")
+
+    const body = JSON.stringify({ id: "evt_fallback" })
+    const signature = nodeSign(body, VERIFICATION_TOKEN)
+
+    await expect(
+      verify({ body, signature, verificationToken: VERIFICATION_TOKEN })
+    ).resolves.toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Adds two helpers for receiving Notion webhooks:

- `verifyWebhookSignature({ body, signature, verificationToken })` returns `Promise<boolean>`. Constant-time HMAC-SHA256 compare against the `X-Notion-Signature` header. Returns `false` on malformed input rather than throwing.
- `signWebhookPayload({ body, verificationToken })` returns the matching `sha256=<hex>` string, for testing webhook handlers without a live subscription.

Both prefer `globalThis.crypto.subtle` and transparently fall back to `node:crypto.webcrypto.subtle` when the global is missing (Node.js 18.0–18.18). They run unchanged on Node.js, Bun, Deno, Vercel Edge Functions, Cloudflare Workers, and modern browsers. No new runtime dependencies.

The algorithm matches the server delivery code in our monorepo (`sendWebhookRequest.ts`): HMAC-SHA256 of the raw body keyed by the verification token, hex-encoded, prefixed with `sha256=`. The initial verification-token handshake uses the same scheme, so one helper covers both.

README gets a "Verifying webhook signatures" section with an Express raw-body example.

Closes #635.

## Test plan

- [x] `npm run build` clean
- [x] `npm test`: 80/80 passing (14 new). One test re-derives the signature via `node:crypto` to pin interop with the server code; another deletes `globalThis.crypto` and re-imports the module to cover the `node:crypto` fallback path locally.
- [x] `npm run lint` clean (added `HMAC` to `.cspell.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)