### PR TITLE
[SDK] Add service overload retry support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,10 +82,11 @@ All API calls flow through `Client.request()` which:
 The client automatically retries failed requests for these error codes:
 
 - `rate_limited` (HTTP 429) - retried for all HTTP methods; respects `retry-after` header if present
+- `service_overload` (HTTP 529) - retried for all HTTP methods; respects `retry-after` header if present
 - `internal_server_error` (HTTP 500) - retried only for idempotent methods (GET, DELETE)
 - `service_unavailable` (HTTP 503) - retried only for idempotent methods (GET, DELETE)
 
-Server errors (500, 503) are only retried for idempotent methods to avoid duplicate side effects. Rate limits (429) are retried for all methods since the server explicitly asks clients to retry.
+Server errors (500, 503) are only retried for idempotent methods to avoid duplicate side effects. Rate limits (429) and service overloads (529) are retried for all methods since the server explicitly asks clients to retry.
 
 Configuration via `ClientOptions.retry`:
 

--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ You may also set a custom `logger` to emit logs to a destination other than `std
 
 The `Client` supports the following options on initialization. These options are all keys in the single constructor parameter.
 
-| Option      | Default value               | Type           | Description                                                                                                                                                  |
-| ----------- | --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `auth`      | `undefined`                 | `string`       | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request.                                                      |
-| `logLevel`  | `LogLevel.WARN`             | `LogLevel`     | Verbosity of logs the instance will produce. By default, logs are written to `stdout`.                                                                       |
-| `timeoutMs` | `DEFAULT_TIMEOUT_MS`        | `number`       | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                                       |
-| `baseUrl`   | `DEFAULT_BASE_URL`          | `string`       | The root URL for sending API requests. This can be changed to test with a mock server.                                                                       |
-| `logger`    | Log to console              | `Logger`       | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`.                       |
-| `agent`     | Default node agent          | `http.Agent`   | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent) |
-| `retry`     | See [constants](#constants) | `RetryOptions` | Configuration for automatic retries on rate limits (429) and server errors (500, 503). See [Automatic retries](#automatic-retries) below.                    |
+| Option      | Default value               | Type           | Description                                                                                                                                                         |
+| ----------- | --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth`      | `undefined`                 | `string`       | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request.                                                             |
+| `logLevel`  | `LogLevel.WARN`             | `LogLevel`     | Verbosity of logs the instance will produce. By default, logs are written to `stdout`.                                                                              |
+| `timeoutMs` | `DEFAULT_TIMEOUT_MS`        | `number`       | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                                              |
+| `baseUrl`   | `DEFAULT_BASE_URL`          | `string`       | The root URL for sending API requests. This can be changed to test with a mock server.                                                                              |
+| `logger`    | Log to console              | `Logger`       | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`.                              |
+| `agent`     | Default node agent          | `http.Agent`   | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent)        |
+| `retry`     | See [constants](#constants) | `RetryOptions` | Configuration for automatic retries on rate limits (429), service overloads (529), and server errors (500, 503). See [Automatic retries](#automatic-retries) below. |
 
 ### Automatic retries
 
@@ -151,10 +151,11 @@ The client automatically retries requests that fail due to rate limiting or tran
 **Retryable errors:**
 
 - `rate_limited` (HTTP 429) - Too many requests; retried for all HTTP methods
+- `service_overload` (HTTP 529) - Service overloaded; retried for all HTTP methods
 - `internal_server_error` (HTTP 500) - Server error; retried only for GET and DELETE
 - `service_unavailable` (HTTP 503) - Service temporarily unavailable; retried only for GET and DELETE
 
-Server errors (500, 503) are only retried for idempotent HTTP methods (GET, DELETE) to avoid duplicate side effects. Rate limits (429) are retried for all methods since the server explicitly asks clients to retry.
+Server errors (500, 503) are only retried for idempotent HTTP methods (GET, DELETE) to avoid duplicate side effects. Rate limits (429) and service overloads (529) are retried for all methods since the server explicitly asks clients to retry.
 
 **Retry behavior:**
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -539,17 +539,21 @@ export default class Client {
 
   /**
    * Determines if an error can be retried based on its error code and method.
-   * Rate limits (429) are always retryable since the server explicitly asks us
-   * to retry. Server errors (500, 503) are only retried for idempotent methods
-   * (GET, DELETE) to avoid duplicate side effects.
+   * Rate limits (429) and service overloads (529) are always retryable since
+   * the server explicitly asks us to retry. Server errors (500, 503) are only
+   * retried for idempotent methods (GET, DELETE) to avoid duplicate side
+   * effects.
    */
   private canRetry(error: unknown, method: Method): boolean {
     if (!APIResponseError.isAPIResponseError(error)) {
       return false
     }
 
-    // Rate limits are always retryable - server says "try again later"
-    if (error.code === APIErrorCode.RateLimited) {
+    // Server says "try again later"; retry these for every HTTP method.
+    if (
+      error.code === APIErrorCode.RateLimited ||
+      error.code === APIErrorCode.ServiceOverload
+    ) {
       return true
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,6 +16,7 @@ export enum APIErrorCode {
   ValidationError = "validation_error",
   ConflictError = "conflict_error",
   InternalServerError = "internal_server_error",
+  ServiceOverload = "service_overload",
   ServiceUnavailable = "service_unavailable",
   GatewayTimeout = "gateway_timeout",
 }
@@ -225,6 +226,7 @@ const httpResponseErrorCodes: { [C in HTTPResponseErrorCode]: true } = {
   [APIErrorCode.ValidationError]: true,
   [APIErrorCode.ConflictError]: true,
   [APIErrorCode.InternalServerError]: true,
+  [APIErrorCode.ServiceOverload]: true,
   [APIErrorCode.ServiceUnavailable]: true,
   [APIErrorCode.GatewayTimeout]: true,
 }
@@ -288,6 +290,7 @@ const apiErrorCodes: { [C in APIErrorCode]: true } = {
   [APIErrorCode.ValidationError]: true,
   [APIErrorCode.ConflictError]: true,
   [APIErrorCode.InternalServerError]: true,
+  [APIErrorCode.ServiceOverload]: true,
   [APIErrorCode.ServiceUnavailable]: true,
   [APIErrorCode.GatewayTimeout]: true,
 }

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -495,6 +495,21 @@ describe("Notion SDK Client", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2)
     })
 
+    it("retries on service overload (529) and succeeds", async () => {
+      setupMockSequence(mockFetch, [
+        { type: "service_overload", options: { retryAfter: "5" } },
+        "success",
+      ])
+
+      const notion = new Client({ fetch: mockFetch, retry: { maxRetries: 2 } })
+      const promise = notion.blocks.retrieve({ block_id: TEST_BLOCK_ID })
+
+      await jest.advanceTimersByTimeAsync(5000)
+      await promise
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
     it("does not retry when retry is disabled", async () => {
       mockFetch.mockResolvedValue(mockResponse("rate_limited"))
 
@@ -739,6 +754,27 @@ describe("Notion SDK Client", () => {
       it("retries POST on rate limit (429)", async () => {
         setupMockSequence(mockFetch, [
           { type: "rate_limited", options: { retryAfter: "1" } },
+          "success",
+        ])
+
+        const notion = new Client({
+          fetch: mockFetch,
+          retry: { maxRetries: 2, initialRetryDelayMs: 1000 },
+        })
+        const promise = notion.pages.create({
+          parent: { page_id: TEST_BLOCK_ID },
+          properties: {},
+        })
+
+        await jest.advanceTimersByTimeAsync(1000)
+        await promise
+
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+      })
+
+      it("retries POST on service overload (529)", async () => {
+        setupMockSequence(mockFetch, [
+          { type: "service_overload", options: { retryAfter: "1" } },
           "success",
         ])
 

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -9,6 +9,7 @@ export const TEST_BLOCK_ID = "9f96555b-cf98-4889-83b0-bd6bbe53911e"
 export type ResponseType =
   | "success"
   | "rate_limited"
+  | "service_overload"
   | "internal_server_error"
   | "service_unavailable"
   | "validation_error"
@@ -26,6 +27,11 @@ const RESPONSE_CONFIG: Record<
 > = {
   success: { status: 200, message: "" },
   rate_limited: { status: 429, code: "rate_limited", message: "Rate limited" },
+  service_overload: {
+    status: 529,
+    code: "service_overload",
+    message: "Service overloaded",
+  },
   internal_server_error: {
     status: 500,
     code: "internal_server_error",


### PR DESCRIPTION
## Description

Adds first-class handling for `service_overload` API responses so HTTP 529 errors are parsed as `APIResponseError`s and retried using the same contract as 429 rate limits. 529 responses are retried for all HTTP methods and continue to respect the `Retry-After` header.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)
