### PR TITLE
Add iterateAllDataSourceRows/collectAllDataSourceRows helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,79 @@ const blocks = await collectPaginatedAPI(notion.blocks.children.list, {
 // Do something with blocks.
 ```
 
+#### `iterateAllDataSourceRows(client, args)`
+
+A single data source query (one filter and sort) returns at most a fixed number
+of rows, 10,000 by default. Once that limit is reached, `has_more` becomes
+`false` and the response carries `request_status.type === "incomplete"`. Plain
+pagination such as `iteratePaginatedAPI` stops there and silently misses the rest
+of a larger data source.
+
+This utility reads every row anyway. It partitions the data source into
+`created_time` windows: it sorts by `created_time` ascending, and whenever a
+window hits the limit it starts a fresh query from the last row's timestamp.
+Each fresh query has a different filter, so it gets its own result budget. Rows
+that share a boundary timestamp are de-duplicated by id, so every row is yielded
+exactly once.
+
+`created_time` is used because it never changes. `last_edited_time` would shift
+rows between windows as they are edited, causing gaps or duplicates.
+
+**Parameters:**
+
+- `client`: A Notion client instance.
+- `args`: The same arguments as `dataSources.query`, minus the fields the helper
+  controls: `start_cursor` (pagination is automatic) and `sorts` (set to
+  `created_time` ascending to partition). `data_source_id` is required. Any
+  `filter` you pass is combined with the window bound using `and`.
+
+**Returns:**
+
+An async iterator over every row in the data source.
+
+**Throws:**
+
+If a single `created_time` value holds more rows than the limit, the window
+cannot be narrowed by time alone. Pass a `filter` in that case so each window
+stays under the limit.
+
+**Example:**
+
+```javascript
+for await (const row of iterateAllDataSourceRows(notion, {
+  data_source_id: dataSourceId,
+})) {
+  // Do something with row.
+}
+```
+
+#### `collectAllDataSourceRows(client, args)`
+
+This utility accepts the same arguments as `iterateAllDataSourceRows`, but
+collects the results into an in-memory array.
+
+Before using this utility, check that the full data source fits in memory. For
+very large data sources, prefer `iterateAllDataSourceRows` and process rows as
+they stream.
+
+**Parameters:**
+
+- `client`: A Notion client instance.
+- `args`: The same arguments as `iterateAllDataSourceRows`.
+
+**Returns:**
+
+An array with every row in the data source.
+
+**Example:**
+
+```javascript
+const rows = await collectAllDataSourceRows(notion, {
+  data_source_id: dataSourceId,
+})
+// Do something with rows.
+```
+
 ### Custom requests
 
 To make requests directly to a Notion API endpoint instead of using the pre-built families of methods, call the `request()` method. For example:

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,6 +5,7 @@ import {
   DataSourceObjectResponse,
   DataSourceViewObjectResponse,
   EquationRichTextItemResponse,
+  GroupFilterOperatorArray,
   ListDataSourceTemplatesResponse,
   MentionRichTextItemResponse,
   PageObjectResponse,
@@ -15,9 +16,13 @@ import {
   PartialDataSourceViewObjectResponse,
   PartialPageObjectResponse,
   PartialUserObjectResponse,
+  PropertyFilter,
+  QueryDataSourceParameters,
+  QueryDataSourceResponse,
   RichTextItemResponse,
   RichTextItemResponseCommon,
   TextRichTextItemResponse,
+  TimestampFilter,
   UserObjectResponse,
 } from "./api-endpoints"
 import type Client from "./Client"
@@ -160,6 +165,179 @@ export async function collectDataSourceTemplates(
     results.push(template)
   }
   return results
+}
+
+type DataSourceRow = QueryDataSourceResponse["results"][number]
+
+/**
+ * A filter the full-query helpers can combine with a created_time window bound.
+ *
+ * A top-level `or` filter is intentionally excluded: the helpers add a
+ * created_time lower bound with `and`, and Notion only supports two levels of
+ * filter nesting, so an `or` at the root leaves no room for the bound. Express
+ * such queries as an `and` group, or run the helper once per `or` branch and
+ * merge the results.
+ */
+export type FullDataSourceQueryFilter =
+  | PropertyFilter
+  | TimestampFilter
+  | { and: GroupFilterOperatorArray }
+
+/**
+ * Arguments for the full-query helpers. The same as `dataSources.query`, minus
+ * the fields the helper controls: `start_cursor` (pagination is automatic) and
+ * `sorts` (the helper sorts by created_time to partition). `filter` is narrowed
+ * to {@link FullDataSourceQueryFilter}.
+ */
+export type FullDataSourceQueryArgs = Omit<
+  QueryDataSourceParameters,
+  "start_cursor" | "sorts" | "filter"
+> & {
+  filter?: FullDataSourceQueryFilter
+}
+
+/**
+ * Iterate over every row of a data source, including rows past the per-query
+ * result limit that `dataSources.query` enforces on large data sources.
+ *
+ * A single query (one filter and sort) returns at most a fixed number of rows
+ * (10,000 by default). Once that limit is reached, `has_more` becomes `false`
+ * and the response carries `request_status.type === "incomplete"`. Plain
+ * pagination such as {@link iteratePaginatedAPI} stops there and silently
+ * misses the rest of the data source.
+ *
+ * This helper works around the limit by partitioning the data source into
+ * created_time windows. It sorts by created_time ascending; whenever a window
+ * reaches the limit, it starts a fresh query from the last row's created_time.
+ * Each fresh query has a different filter, so it gets its own result budget.
+ * Rows that share a boundary timestamp are de-duplicated by id, so every row is
+ * yielded exactly once.
+ *
+ * created_time is used because it never changes. last_edited_time would shift
+ * rows between windows as they are edited, causing gaps or duplicates.
+ *
+ * Throws if a single created_time value holds more rows than the limit, since
+ * the window cannot be narrowed by time alone. Add a filter in that case so
+ * each window stays under the limit.
+ *
+ * Example (given a notion Client called `notion`):
+ *
+ * ```
+ * for await (const row of iterateAllDataSourceRows(notion, {
+ *   data_source_id: dataSourceId,
+ * })) {
+ *   // Do something with row.
+ * }
+ * ```
+ *
+ * @param client A Notion client instance.
+ * @param args Query arguments. `start_cursor` and `sorts` are managed by the
+ *   helper; `filter` is combined with the created_time window bound.
+ */
+export async function* iterateAllDataSourceRows(
+  client: Client,
+  args: FullDataSourceQueryArgs
+): AsyncIterableIterator<DataSourceRow> {
+  const seenRowIds = new Set<string>()
+  let windowStart: string | undefined = undefined
+
+  for (;;) {
+    let limitReached = false
+    let lastCreatedTime: string | undefined = undefined
+    let cursor: string | undefined = undefined
+
+    do {
+      const response = await client.dataSources.query({
+        ...args,
+        sorts: [{ timestamp: "created_time", direction: "ascending" }],
+        filter: createdTimeLowerBound(args.filter, windowStart),
+        start_cursor: cursor,
+      })
+      for (const row of response.results) {
+        if (isFullPage(row)) {
+          lastCreatedTime = row.created_time
+        }
+        if (!seenRowIds.has(row.id)) {
+          seenRowIds.add(row.id)
+          yield row
+        }
+      }
+      if (response.request_status?.type === "incomplete") {
+        limitReached = true
+      }
+      cursor = response.next_cursor ?? undefined
+    } while (cursor)
+
+    if (!limitReached) {
+      return
+    }
+    if (lastCreatedTime === undefined || lastCreatedTime === windowStart) {
+      throw new Error(
+        "iterateAllDataSourceRows cannot make progress: the per-query result " +
+          "limit was reached but the created_time window could not advance " +
+          `past ${String(lastCreatedTime)}. More rows share this timestamp ` +
+          "than the limit allows. Add a filter to narrow the query."
+      )
+    }
+    windowStart = lastCreatedTime
+  }
+}
+
+/**
+ * Collect every row of a data source into an in-memory array, including rows
+ * past the per-query result limit. See {@link iterateAllDataSourceRows} for how
+ * the limit is handled.
+ *
+ * Before using this, check that the full data source fits in memory. For very
+ * large data sources, prefer {@link iterateAllDataSourceRows} and process rows
+ * as they stream.
+ *
+ * Example (given a notion Client called `notion`):
+ *
+ * ```
+ * const rows = await collectAllDataSourceRows(notion, {
+ *   data_source_id: dataSourceId,
+ * })
+ * // Do something with rows.
+ * ```
+ *
+ * @param client A Notion client instance.
+ * @param args Query arguments. See {@link iterateAllDataSourceRows}.
+ */
+export async function collectAllDataSourceRows(
+  client: Client,
+  args: FullDataSourceQueryArgs
+): Promise<DataSourceRow[]> {
+  const rows: DataSourceRow[] = []
+  for await (const row of iterateAllDataSourceRows(client, args)) {
+    rows.push(row)
+  }
+  return rows
+}
+
+/**
+ * Combine a caller-provided filter with the created_time lower bound used to
+ * advance the partition window. Returns the filter unchanged for the first
+ * window, which has no bound yet.
+ */
+function createdTimeLowerBound(
+  filter: FullDataSourceQueryFilter | undefined,
+  windowStart: string | undefined
+): FullDataSourceQueryFilter | undefined {
+  if (windowStart === undefined) {
+    return filter
+  }
+  const bound: TimestampFilter = {
+    timestamp: "created_time",
+    created_time: { on_or_after: windowStart },
+  }
+  if (filter === undefined) {
+    return bound
+  }
+  if ("and" in filter) {
+    return { and: [...filter.and, bound] }
+  }
+  return { and: [filter, bound] }
 }
 
 type ObjectResponse =

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,8 @@ export {
   iteratePaginatedAPI,
   collectDataSourceTemplates,
   iterateDataSourceTemplates,
+  iterateAllDataSourceRows,
+  collectAllDataSourceRows,
   isFullBlock,
   isFullDataSource,
   isFullDatabase,
@@ -259,6 +261,10 @@ export {
   extractDatabaseId,
   extractPageId,
   extractBlockId,
+} from "./helpers"
+export type {
+  FullDataSourceQueryArgs,
+  FullDataSourceQueryFilter,
 } from "./helpers"
 export { verifyWebhookSignature, signWebhookPayload } from "./webhooks"
 export type { VerifyWebhookSignatureArgs } from "./webhooks"

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,8 @@
 import {
+  collectAllDataSourceRows,
   collectDataSourceTemplates,
   collectPaginatedAPI,
+  iterateAllDataSourceRows,
   iterateDataSourceTemplates,
   iteratePaginatedAPI,
 } from "../src/helpers"
@@ -286,6 +288,212 @@ describe("Notion API helpers", () => {
 
         const call = mockFetch.mock.calls[0]
         expect(call?.[0]).toContain("start_cursor=initial-cursor")
+      })
+    })
+  })
+
+  describe("Full data source query helpers", () => {
+    let mockFetch: jest.MockedFn<typeof fetch>
+    let client: Client
+
+    beforeEach(() => {
+      mockFetch = jest.fn()
+      client = new Client({ auth: "test-token", fetch: mockFetch })
+    })
+
+    function page(id: string, createdTime: string) {
+      return {
+        object: "page",
+        id,
+        url: `https://notion.so/${id}`,
+        created_time: createdTime,
+      }
+    }
+
+    function queryResponse(
+      results: Array<ReturnType<typeof page>>,
+      opts: { nextCursor?: string | null; incomplete?: boolean } = {}
+    ): Response {
+      const nextCursor = opts.nextCursor ?? null
+      const body: Record<string, unknown> = {
+        object: "list",
+        type: "page_or_data_source",
+        page_or_data_source: {},
+        results,
+        has_more: nextCursor !== null,
+        next_cursor: nextCursor,
+      }
+      if (opts.incomplete) {
+        body["request_status"] = {
+          type: "incomplete",
+          incomplete_reason: "query_result_limit_reached",
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve(JSON.stringify(body)),
+      } as Response
+    }
+
+    function bodyOf(call: Parameters<typeof fetch> | undefined) {
+      return JSON.parse(String(call?.[1]?.body))
+    }
+
+    describe(iterateAllDataSourceRows, () => {
+      it("Returns a single complete window without re-querying", async () => {
+        mockFetch.mockResolvedValueOnce(
+          queryResponse([
+            page("r1", "2024-01-01T00:00:00.000Z"),
+            page("r2", "2024-01-02T00:00:00.000Z"),
+          ])
+        )
+
+        const ids: string[] = []
+        for await (const row of iterateAllDataSourceRows(client, {
+          data_source_id: "ds-1",
+        })) {
+          ids.push(row.id)
+        }
+
+        expect(ids).toEqual(["r1", "r2"])
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        const body = bodyOf(mockFetch.mock.calls[0])
+        expect(body.sorts).toEqual([
+          { timestamp: "created_time", direction: "ascending" },
+        ])
+        expect(body.filter).toBeUndefined()
+        expect(body.start_cursor).toBeFalsy()
+      })
+
+      it("Advances past the per-query limit and de-duplicates boundaries", async () => {
+        // Window 1: two pages, the second hits the limit (incomplete).
+        mockFetch
+          .mockResolvedValueOnce(
+            queryResponse(
+              [
+                page("r1", "2024-01-01T00:00:00.000Z"),
+                page("r2", "2024-01-02T00:00:00.000Z"),
+              ],
+              { nextCursor: "c1" }
+            )
+          )
+          .mockResolvedValueOnce(
+            queryResponse(
+              [
+                page("r3", "2024-01-03T00:00:00.000Z"),
+                page("r4", "2024-01-04T00:00:00.000Z"),
+              ],
+              { incomplete: true }
+            )
+          )
+          // Window 2: starts at the last created_time, re-sees r4, then finishes.
+          .mockResolvedValueOnce(
+            queryResponse([
+              page("r4", "2024-01-04T00:00:00.000Z"),
+              page("r5", "2024-01-05T00:00:00.000Z"),
+            ])
+          )
+
+        const ids: string[] = []
+        for await (const row of iterateAllDataSourceRows(client, {
+          data_source_id: "ds-1",
+        })) {
+          ids.push(row.id)
+        }
+
+        expect(ids).toEqual(["r1", "r2", "r3", "r4", "r5"])
+        expect(mockFetch).toHaveBeenCalledTimes(3)
+        // Inner pagination carried the cursor within window 1.
+        expect(bodyOf(mockFetch.mock.calls[1]).start_cursor).toEqual("c1")
+        // Window 2 reset the cursor and added the created_time lower bound.
+        expect(bodyOf(mockFetch.mock.calls[2]).start_cursor).toBeFalsy()
+        expect(bodyOf(mockFetch.mock.calls[2]).filter).toEqual({
+          timestamp: "created_time",
+          created_time: { on_or_after: "2024-01-04T00:00:00.000Z" },
+        })
+      })
+
+      it("Combines a caller filter with the window bound using and", async () => {
+        const filter = { property: "Status", status: { equals: "Done" } }
+        mockFetch
+          .mockResolvedValueOnce(
+            queryResponse([page("r1", "2024-01-01T00:00:00.000Z")], {
+              incomplete: true,
+            })
+          )
+          .mockResolvedValueOnce(
+            queryResponse([
+              page("r1", "2024-01-01T00:00:00.000Z"),
+              page("r2", "2024-02-01T00:00:00.000Z"),
+            ])
+          )
+
+        const ids: string[] = []
+        for await (const row of iterateAllDataSourceRows(client, {
+          data_source_id: "ds-1",
+          filter,
+        })) {
+          ids.push(row.id)
+        }
+
+        expect(ids).toEqual(["r1", "r2"])
+        // First window: caller filter only.
+        expect(bodyOf(mockFetch.mock.calls[0]).filter).toEqual(filter)
+        // Second window: caller filter AND created_time bound.
+        expect(bodyOf(mockFetch.mock.calls[1]).filter).toEqual({
+          and: [
+            filter,
+            {
+              timestamp: "created_time",
+              created_time: { on_or_after: "2024-01-01T00:00:00.000Z" },
+            },
+          ],
+        })
+      })
+
+      it("Throws when one created_time holds more rows than the limit", async () => {
+        const sameTime = "2024-01-01T00:00:00.000Z"
+        mockFetch
+          .mockResolvedValueOnce(
+            queryResponse([page("r1", sameTime), page("r2", sameTime)], {
+              incomplete: true,
+            })
+          )
+          .mockResolvedValueOnce(
+            queryResponse([page("r1", sameTime), page("r2", sameTime)], {
+              incomplete: true,
+            })
+          )
+
+        await expect(
+          collectAllDataSourceRows(client, { data_source_id: "ds-1" })
+        ).rejects.toThrow("cannot make progress")
+      })
+    })
+
+    describe(collectAllDataSourceRows, () => {
+      it("Collects every row across windows into an array", async () => {
+        mockFetch
+          .mockResolvedValueOnce(
+            queryResponse([page("r1", "2024-01-01T00:00:00.000Z")], {
+              incomplete: true,
+            })
+          )
+          .mockResolvedValueOnce(
+            queryResponse([
+              page("r1", "2024-01-01T00:00:00.000Z"),
+              page("r2", "2024-01-02T00:00:00.000Z"),
+            ])
+          )
+
+        const rows = await collectAllDataSourceRows(client, {
+          data_source_id: "ds-1",
+        })
+
+        expect(rows.map(r => r.id)).toEqual(["r1", "r2"])
+        expect(mockFetch).toHaveBeenCalledTimes(2)
       })
     })
   })


### PR DESCRIPTION
## Description

Adds two helpers for reading a data source past the per-query result limit.

A single `dataSources.query` returns at most 10,000 results. Once that limit is reached, `has_more` becomes `false` and the response carries `request_status.type === "incomplete"` (`incomplete_reason: "query_result_limit_reached"`). The existing `iteratePaginatedAPI` / `collectPaginatedAPI` helpers follow `next_cursor` until `has_more` is `false`, so on a larger data source they stop at 10,000 and silently return a partial result. This is a common source of confusion for connections doing full exports.

The new helpers work around the limit:

- `iterateAllDataSourceRows(client, args)` — async iterator over every row.
- `collectAllDataSourceRows(client, args)` — collects every row into an array.

They partition the data source into `created_time` windows: sort `created_time` ascending, and each time a window hits the limit, start a new query from the last row's `created_time`. Each new filter is a distinct query with its own 10,000-row budget. Boundary rows that share a timestamp are de-duplicated by id. `created_time` is used because it never changes, unlike `last_edited_time`, which would move rows between windows. They throw a clear error if a single `created_time` (minute granularity) holds more rows than the limit, since the window can't be narrowed by time alone.

`args.filter` is narrowed to `PropertyFilter | TimestampFilter | { and: GroupFilterOperatorArray }` so the helper can `and` the window bound onto it within Notion's two-level nesting limit; `sorts` and `start_cursor` are managed by the helper.

Note: this is data-source-only. View queries (`GET /v1/views/{view_id}/queries/{query_id}`) hit the same limit but paginate a fixed, already-capped result set and accept no filter while paginating, so they can't be windowed this way; query the underlying data source instead.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Unit tests in `test/helpers.test.ts` cover: a single complete window (no re-query), advancing past the limit with boundary de-duplication, combining a caller filter with the window bound via `and`, and the stall error when one `created_time` exceeds the limit. `npm run build` and `npm run lint` pass; 12/12 helper tests pass.

Manually verified against a 20,000+ row dev data source with the per-query limit enabled: a plain query caps at exactly 10,000 with `request_status: incomplete`, and `collectAllDataSourceRows` recovers the full set with no duplicates. Cross-checked that the windowing recovers the identical row set regardless of where windows break.

## Screenshots

N/A
