### PR TITLE
Advance full-query windows on data-source rows, not only pages

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -254,7 +254,11 @@ export async function* iterateAllDataSourceRows(
         start_cursor: cursor,
       })
       for (const row of response.results) {
-        if (isFullPage(row)) {
+        // Wiki data sources can return child data-source rows alongside pages.
+        // Both carry created_time and either can be the window's boundary row,
+        // so advance on either; reading only pages would stall a window made up
+        // of data-source rows and throw spuriously.
+        if (isFullPageOrDataSource(row)) {
           lastCreatedTime = row.created_time
         }
         if (!seenRowIds.has(row.id)) {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -310,8 +310,17 @@ describe("Notion API helpers", () => {
       }
     }
 
+    // A child data-source row, as returned when querying a wiki data source.
+    function dataSource(id: string, createdTime: string) {
+      return {
+        object: "data_source",
+        id,
+        created_time: createdTime,
+      }
+    }
+
     function queryResponse(
-      results: Array<ReturnType<typeof page>>,
+      results: Array<ReturnType<typeof page> | ReturnType<typeof dataSource>>,
       opts: { nextCursor?: string | null; incomplete?: boolean } = {}
     ): Response {
       const nextCursor = opts.nextCursor ?? null
@@ -450,6 +459,43 @@ describe("Notion API helpers", () => {
               created_time: { on_or_after: "2024-01-01T00:00:00.000Z" },
             },
           ],
+        })
+      })
+
+      it("Advances on a data-source boundary row, not only pages", async () => {
+        // Window 1 ends at the limit on a child data-source row (wiki data
+        // source). The window must advance from that row's created_time, even
+        // though it is not a page.
+        mockFetch
+          .mockResolvedValueOnce(
+            queryResponse(
+              [
+                page("r1", "2024-01-01T00:00:00.000Z"),
+                dataSource("ds-child", "2024-01-02T00:00:00.000Z"),
+              ],
+              { incomplete: true }
+            )
+          )
+          .mockResolvedValueOnce(
+            queryResponse([
+              dataSource("ds-child", "2024-01-02T00:00:00.000Z"),
+              page("r2", "2024-01-03T00:00:00.000Z"),
+            ])
+          )
+
+        const ids: string[] = []
+        for await (const row of iterateAllDataSourceRows(client, {
+          data_source_id: "ds-1",
+        })) {
+          ids.push(row.id)
+        }
+
+        expect(ids).toEqual(["r1", "ds-child", "r2"])
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+        // The second window advanced from the data-source row's created_time.
+        expect(bodyOf(mockFetch.mock.calls[1]).filter).toEqual({
+          timestamp: "created_time",
+          created_time: { on_or_after: "2024-01-02T00:00:00.000Z" },
         })
       })
 


### PR DESCRIPTION
## Description

Follow-up to #730 (the full-query helper PR). The `isFullPageOrDataSource` fix was committed ~4 minutes after #730 was squash-merged, so it missed the merge. This PR lands just that fix on top of current `main`.

`dataSources.query` can return child data-source rows (in wiki data sources) alongside pages: `QueryDataSourceResponse["results"]` includes `DataSourceObjectResponse`, which also carries `created_time`. The `iterateAllDataSourceRows` window-advance logic read `created_time` only from `isFullPage(row)` rows. So if a truncated window's boundary row was a data source, or a window held only child data sources, the loop could restart from an older timestamp or throw "cannot make progress" spuriously, even though more rows remained.

The fix reads `created_time` via `isFullPageOrDataSource(row)`, which narrows to `PageObjectResponse | DataSourceObjectResponse` (both have `created_time`), so either kind of boundary row advances the window. The same fix shipped to the docs guide (makenotion/notion-next#259208) and the cookbook example (makenotion/notion-cookbook#21).

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Added a regression test that ends a window on a child data-source row (not a page) and asserts the next window advances from that row's `created_time` instead of stalling or throwing.

## Screenshots

N/A