### PR TITLE
Export rich text annotation types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,10 @@
  * @packageDocumentation
  */
 
+import type { RichTextItemResponseCommon } from "./api-endpoints"
+
 export type {
+  ApiColor,
   AppendBlockChildrenParameters,
   AppendBlockChildrenResponse,
   AudioBlockObjectResponse,
@@ -148,6 +151,7 @@ export type {
   QuoteBlockObjectResponse,
   RelationPropertyItemObjectResponse,
   RichTextItemResponse,
+  RichTextItemResponseCommon,
   RichTextPropertyItemObjectResponse,
   RollupPropertyItemObjectResponse,
   SearchParameters,
@@ -219,6 +223,7 @@ export type {
   ViewDeletedWebhookPayload,
   ViewUpdatedWebhookPayload,
 } from "./api-endpoints"
+export type AnnotationResponse = RichTextItemResponseCommon["annotations"]
 export { default as Client } from "./Client"
 export { LogLevel, Logger } from "./logging"
 export {


### PR DESCRIPTION
## Summary

Fixes #689 by making the rich text annotation types available from the package entrypoint:

- export `ApiColor` from `src/index.ts`
- export `RichTextItemResponseCommon`
- add a public `AnnotationResponse` alias based on `RichTextItemResponseCommon["annotations"]`

This avoids editing the generated API endpoint files while still exposing the types users need for validating `RichTextItemResponse.annotations`.

## Verification

- `./node_modules/.bin/prettier --check src/index.ts`
- checked that the new export declarations are present
- `git diff --check`

I could not run the normal `npm run build` / husky hook in this environment because `npm`/`npx` are not available. Running `tsc` directly also hits the existing local setup issue that Node/DOM globals such as `Buffer`, `fetch`, `FormData`, and `URL` are unavailable without the usual npm-installed type environment.
