### PR TITLE
Allow null start_cursor in pagination helper constraint

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,7 +28,11 @@ import {
 import type Client from "./Client"
 
 type PaginatedArgs = {
-  start_cursor?: string
+  // `null` is accepted alongside `string` because request parameter types
+  // (e.g. `QueryDataSourceParameters`) allow piping `next_cursor` (which can
+  // be `null`) back as `start_cursor`. Without it, those endpoint methods no
+  // longer satisfy the `Args extends PaginatedArgs` constraint.
+  start_cursor?: string | null
 }
 
 type PaginatedList<T> = {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,10 +28,6 @@ import {
 import type Client from "./Client"
 
 type PaginatedArgs = {
-  // `null` is accepted alongside `string` because request parameter types
-  // (e.g. `QueryDataSourceParameters`) allow piping `next_cursor` (which can
-  // be `null`) back as `start_cursor`. Without it, those endpoint methods no
-  // longer satisfy the `Args extends PaginatedArgs` constraint.
   start_cursor?: string | null
 }
 

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -100,6 +100,41 @@ describe("Notion API helpers", () => {
       expect(results).toEqual([1, 2, 3, 4, 5])
       expect(mockPaginatedEndpoint).toHaveBeenCalledTimes(2)
     })
+
+    // Regression test: endpoint methods whose `start_cursor` accepts
+    // `string | null` (e.g. `dataSources.query`) must satisfy the
+    // `Args extends PaginatedArgs` constraint. This is primarily a
+    // compile-time check.
+    it("Accepts client endpoint methods with nullable start_cursor", async () => {
+      const mockFetch = jest.fn<
+        ReturnType<typeof fetch>,
+        Parameters<typeof fetch>
+      >()
+      const client = new Client({ auth: "test-token", fetch: mockFetch })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () =>
+          Promise.resolve(
+            JSON.stringify({
+              object: "list",
+              type: "page_or_data_source",
+              page_or_data_source: {},
+              results: [],
+              has_more: false,
+              next_cursor: null,
+            })
+          ),
+      } as Response)
+
+      const results = await collectPaginatedAPI(client.dataSources.query, {
+        data_source_id: "data-source-123",
+      })
+
+      expect(results).toEqual([])
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe("Data source template helpers", () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -101,10 +101,6 @@ describe("Notion API helpers", () => {
       expect(mockPaginatedEndpoint).toHaveBeenCalledTimes(2)
     })
 
-    // Regression test: endpoint methods whose `start_cursor` accepts
-    // `string | null` (e.g. `dataSources.query`) must satisfy the
-    // `Args extends PaginatedArgs` constraint. This is primarily a
-    // compile-time check.
     it("Accepts client endpoint methods with nullable start_cursor", async () => {
       const mockFetch = jest.fn<
         ReturnType<typeof fetch>,


### PR DESCRIPTION
## Summary

Fixes #743.

v5.23.0 changed endpoint request parameter types to accept `start_cursor?: string | null` (so `next_cursor` can be piped back directly), but the `PaginatedArgs` constraint used by `iteratePaginatedAPI` / `collectPaginatedAPI` in `src/helpers.ts` still only allowed `string`.

Under `strictNullChecks`, `{ start_cursor?: string | null }` does not extend `{ start_cursor?: string }`, so endpoint methods like `notion.dataSources.query` no longer satisfy `Args extends PaginatedArgs`. Generic inference falls back to the constraint, and callers get a confusing error:

```
error TS2345: Argument of type '(args: WithAuth<QueryDataSourceParameters>) => Promise<QueryDataSourceResponse>' is not assignable to parameter of type '(args: PaginatedArgs) => Promise<PaginatedList<...>>'.
  ...
      Property 'data_source_id' is missing in type 'PaginatedArgs' but required in type 'QueryDataSourcePathParameters'.
```

## Background: how the regression was introduced

The `| null` widening came from #723 ("Allow `null` for `start_cursor` in pagination types", merged 2026-05-20, first released in v5.23.0 on 2026-07-08). That PR regenerated the endpoint types from the OpenAPI spec (11 endpoints picked up `start_cursor?: string | null`) and also fixed the hand-maintained parts of `Client.ts` — but only because the regenerated types **broke the build** there (`QueryParams` didn't accept `null`).

`src/helpers.ts` was left untouched because nothing surfaced it:

- `PaginatedArgs` is only used as a generic constraint, and no code in this repo passes a real endpoint method (e.g. `client.dataSources.query`) to `iteratePaginatedAPI` / `collectPaginatedAPI`, so the build stayed green.
- The existing helper tests use hand-rolled mocks typed `[{ start_cursor?: string }]` — i.e. the old shape — so tests stayed green too.

The constraint violation only materializes in downstream user code, which is why it shipped unnoticed. The regression test added here closes that gap: it hands `client.dataSources.query` directly to `collectPaginatedAPI`, so any future divergence between the endpoint parameter types and `PaginatedArgs` fails to compile in CI.

## Changes

- Widen `PaginatedArgs.start_cursor` to `string | null` to match the endpoint parameter types. This is a types-only change: the runtime already strips `null` cursors from the query string and JSON body as of v5.23.0.
- Add a regression test that passes `client.dataSources.query` to `collectPaginatedAPI`, which fails to compile without the fix.

## Test plan

- [x] `npm run build` (tsc) passes
- [x] `npm test` passes (95 tests)
- [x] Verified the reproduction from #743 compiles against the built output with this change, and fails without it

Made with [Cursor](https://cursor.com)