### PR TITLE
[AI] Add `create` method to `client.blocks.meetingNotes`

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -168,6 +168,9 @@ import {
   getAsyncTask,
 } from "./api-endpoints"
 import {
+  type CreateMeetingNoteParameters,
+  type CreateMeetingNoteResponse,
+  createMeetingNote,
   type QueryMeetingNotesResponse,
   queryMeetingNotes,
 } from "./api-endpoints/meeting-notes"
@@ -729,6 +732,22 @@ export default class Client {
     },
 
     meetingNotes: {
+      /**
+       * Create a meeting note
+       */
+      create: (
+        args: WithAuth<CreateMeetingNoteParameters>
+      ): Promise<CreateMeetingNoteResponse> => {
+        this.warnUnknownParams(args, createMeetingNote)
+        return this.request<CreateMeetingNoteResponse>({
+          path: createMeetingNote.path(),
+          method: createMeetingNote.method,
+          query: pick(args, createMeetingNote.queryParams),
+          body: pick(args, createMeetingNote.bodyParams),
+          auth: args?.auth,
+        })
+      },
+
       /**
        * Query meeting notes
        */

--- a/src/api-endpoints/meeting-notes.ts
+++ b/src/api-endpoints/meeting-notes.ts
@@ -2,10 +2,149 @@
 // Note: This is a generated file. DO NOT EDIT!
 
 import type {
+  IdRequest,
   IdResponse,
   PartialUserObjectResponse,
   RichTextItemResponse,
 } from "./common"
+
+type CreateMeetingNoteBodyParameters = {
+  // Audio or video source for the meeting note.
+  source:
+    | {
+        // Always "file_upload".
+        type: "file_upload"
+        // ID of a completed public API file upload.
+        file_upload_id: IdRequest
+      }
+    | {
+        // Always "block".
+        type: "block"
+        // ID of an existing audio, video, or file block.
+        block_id: IdRequest
+      }
+  // Parent page for the new meeting note. Required when source.type is file_upload.
+  parent?: {
+    // Always "page_id".
+    type: "page_id"
+    // Page ID where the meeting note should be created. Required for file_upload sources.
+    page_id: IdRequest
+  }
+  // Title for the meeting note.
+  title?: string
+  // Language hint for transcription. Defaults to automatic detection.
+  language?:
+    | "auto"
+    | "en"
+    | "zh-CN"
+    | "zh-TW"
+    | "es"
+    | "fr"
+    | "de"
+    | "ja"
+    | "ko"
+    | "pt"
+    | "ru"
+    | "th"
+    | "vi"
+    | "id"
+    | "da"
+    | "fi"
+    | "no"
+    | "nl"
+    | "it"
+    | "sv"
+    | "ar"
+    | "he"
+    | "pl"
+  // Optional processing settings.
+  options?: {
+    // Whether to start summary generation after transcription.
+    kickoff_summary?: boolean
+  }
+}
+
+export type CreateMeetingNoteParameters = CreateMeetingNoteBodyParameters
+
+export type CreateMeetingNoteResponse =
+  | {
+      // Always "block".
+      object: "block"
+      // The ID of the meeting note block.
+      id: IdResponse
+    }
+  | {
+      // Always "block".
+      object: "block"
+      // The ID of the meeting note block.
+      id: IdResponse
+      // Always "meeting_notes".
+      type: "meeting_notes"
+      // Meeting note content fields.
+      meeting_notes: {
+        // Title of the meeting note as rich text.
+        title?: Array<RichTextItemResponse>
+        // Current processing status of the meeting note transcription.
+        status?:
+          | "transcription_not_started"
+          | "transcription_paused"
+          | "transcription_in_progress"
+          | "transcription_failed"
+          | "summary_in_progress"
+          | "notes_ready"
+        // Block IDs for each tab (summary, notes, transcript).
+        children?: {
+          // Block ID of the AI summary tab.
+          summary_block_id?: IdResponse
+          // Block ID of the meeting notes tab.
+          notes_block_id?: IdResponse
+          // Block ID of the transcript tab.
+          transcript_block_id?: IdResponse
+        }
+        // Calendar event metadata associated with this meeting note.
+        calendar_event?: {
+          // ISO-8601 start time of the calendar event.
+          start_time: string
+          // ISO-8601 end time of the calendar event.
+          end_time: string
+          // List of attendee user IDs.
+          attendees?: Array<IdResponse>
+        }
+        // Start and end times of the actual recording.
+        recording?: {
+          // ISO-8601 timestamp when the recording started.
+          start_time?: string
+          // ISO-8601 timestamp when the recording ended.
+          end_time?: string
+        }
+      }
+      // ISO-8601 timestamp when this meeting note was created.
+      created_time: string
+      // ISO-8601 timestamp when this meeting note was last edited.
+      last_edited_time: string
+      // User who created this meeting note.
+      created_by: PartialUserObjectResponse
+      // User who last edited this meeting note.
+      last_edited_by: PartialUserObjectResponse
+      // Whether this block has child blocks.
+      has_children: boolean
+      // Whether this meeting note is in the trash.
+      in_trash: boolean
+      /** @deprecated Use `in_trash` instead. Present for backwards compatibility with API versions prior to 2026-03-11. */
+      archived: boolean
+    }
+
+/**
+ * Create a meeting note
+ */
+export const createMeetingNote = {
+  method: "post",
+  pathParams: [],
+  queryParams: [],
+  bodyParams: ["source", "parent", "title", "language", "options"],
+
+  path: (): string => `blocks/meeting_notes`,
+} as const
 
 type QueryMeetingNotesBodyParameters = {
   // Optional filter for querying meeting notes. Supports combinator (and/or) and property

--- a/src/api-endpoints/meeting-notes.ts
+++ b/src/api-endpoints/meeting-notes.ts
@@ -9,27 +9,6 @@ import type {
 } from "./common"
 
 type CreateMeetingNoteBodyParameters = {
-  // Audio or video source for the meeting note.
-  source:
-    | {
-        // Always "file_upload".
-        type: "file_upload"
-        // ID of a completed public API file upload.
-        file_upload_id: IdRequest
-      }
-    | {
-        // Always "block".
-        type: "block"
-        // ID of an existing audio, video, or file block.
-        block_id: IdRequest
-      }
-  // Parent page for the new meeting note. Required when source.type is file_upload.
-  parent?: {
-    // Always "page_id".
-    type: "page_id"
-    // Page ID where the meeting note should be created. Required for file_upload sources.
-    page_id: IdRequest
-  }
   // Title for the meeting note.
   title?: string
   // Language hint for transcription. Defaults to automatic detection.
@@ -62,7 +41,35 @@ type CreateMeetingNoteBodyParameters = {
     // Whether to start summary generation after transcription.
     kickoff_summary?: boolean
   }
-}
+} & (
+  | {
+      // Audio or video source for the meeting note.
+      source: {
+        // Always "file_upload".
+        type: "file_upload"
+        // ID of a completed public API file upload.
+        file_upload_id: IdRequest
+      }
+      // Parent page for the new meeting note.
+      parent: {
+        // Always "page_id".
+        type: "page_id"
+        // Page ID where the meeting note should be created. Required for file_upload sources.
+        page_id: IdRequest
+      }
+    }
+  | {
+      // Audio or video source for the meeting note.
+      source: {
+        // Always "block".
+        type: "block"
+        // ID of an existing audio, video, or file block.
+        block_id: IdRequest
+      }
+      // Not accepted for block sources.
+      parent?: never
+    }
+)
 
 export type CreateMeetingNoteParameters = CreateMeetingNoteBodyParameters
 
@@ -141,7 +148,7 @@ export const createMeetingNote = {
   method: "post",
   pathParams: [],
   queryParams: [],
-  bodyParams: ["source", "parent", "title", "language", "options"],
+  bodyParams: ["title", "language", "options", "source", "parent"],
 
   path: (): string => `blocks/meeting_notes`,
 } as const

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -122,6 +122,53 @@ describe("Notion SDK Client", () => {
       expect(formData["file"].size).toEqual(4)
     })
 
+    it("calls create meeting note API", async () => {
+      await notion.blocks.meetingNotes.create({
+        source: {
+          type: "file_upload",
+          file_upload_id: "a02fc1d3-db8b-45c5-a222-27595b15aea7",
+        },
+        parent: {
+          type: "page_id",
+          page_id: "c02fc1d3-db8b-45c5-a222-27595b15aea7",
+        },
+        title: "Weekly sync",
+        language: "en",
+        options: {
+          kickoff_summary: true,
+        },
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.notion.com/v1/blocks/meeting_notes",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Notion-Version": "2025-09-03",
+            "user-agent": expect.stringContaining("notionhq-client"),
+            "content-type": "application/json",
+          }),
+        })
+      )
+
+      const requestBody = getFirstRequestBody()
+      expect(requestBody).toEqual({
+        source: {
+          type: "file_upload",
+          file_upload_id: "a02fc1d3-db8b-45c5-a222-27595b15aea7",
+        },
+        parent: {
+          type: "page_id",
+          page_id: "c02fc1d3-db8b-45c5-a222-27595b15aea7",
+        },
+        title: "Weekly sync",
+        language: "en",
+        options: {
+          kickoff_summary: true,
+        },
+      })
+    })
+
     it("calls query meeting notes API without filter", async () => {
       await notion.blocks.meetingNotes.query({})
 


### PR DESCRIPTION
## Description

Companion to makenotion/notion-next#292926, which documents the Create Meeting Note endpoint, and makenotion/notion-next#295243, which corrects its source-specific request schema.

- Add generated request and response types for POST /v1/blocks/meeting_notes
- Add client.blocks.meetingNotes.create()
- Require parent for file_upload sources and exclude it for block sources in generated types
- Add a focused client request test

Unrelated generated OpenAPI drift was excluded. Merge after makenotion/notion-next#295243.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

## Screenshots

Not applicable.