### PR TITLE
[SDK] Fix partial response type guards

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -378,7 +378,7 @@ export function isFullPage(
 export function isFullDataSource(
   response: ObjectResponse
 ): response is DataSourceObjectResponse {
-  return response.object === "data_source"
+  return response.object === "data_source" && "title" in response
 }
 
 /**
@@ -387,7 +387,7 @@ export function isFullDataSource(
 export function isFullDatabase(
   response: ObjectResponse
 ): response is DatabaseObjectResponse {
-  return response.object === "database"
+  return response.object === "database" && "title" in response
 }
 
 /**

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -6,9 +6,98 @@ import {
   iterateDataSourceTemplates,
   iteratePaginatedAPI,
 } from "../src/helpers"
-import { Client } from "../src"
+import {
+  Client,
+  DatabaseObjectResponse,
+  DataSourceObjectResponse,
+  isFullDatabase,
+  isFullDataSource,
+  PartialDatabaseObjectResponse,
+  PartialDataSourceObjectResponse,
+} from "../src"
 
 describe("Notion API helpers", () => {
+  describe("full object type guards", () => {
+    const dataSource = (): DataSourceObjectResponse => ({
+      object: "data_source",
+      id: "data-source-id",
+      title: [],
+      description: [],
+      parent: { type: "database_id", database_id: "database-id" },
+      database_parent: { type: "page_id", page_id: "page-id" },
+      is_inline: false,
+      in_trash: false,
+      archived: false,
+      created_time: "2026-08-13T00:00:00.000Z",
+      last_edited_time: "2026-08-13T00:00:00.000Z",
+      created_by: { object: "user", id: "user-id" },
+      last_edited_by: { object: "user", id: "user-id" },
+      properties: {},
+      icon: null,
+      cover: null,
+      url: "https://www.notion.so/data-source-id",
+      public_url: null,
+    })
+
+    const database = (): DatabaseObjectResponse => ({
+      object: "database",
+      id: "database-id",
+      title: [],
+      description: [],
+      parent: { type: "page_id", page_id: "page-id" },
+      is_inline: false,
+      in_trash: false,
+      archived: false,
+      is_locked: false,
+      created_time: "2026-08-13T00:00:00.000Z",
+      last_edited_time: "2026-08-13T00:00:00.000Z",
+      data_sources: [],
+      icon: null,
+      cover: null,
+      url: "https://www.notion.so/database-id",
+      public_url: null,
+    })
+
+    const getDataSourceTitle = (
+      response: DataSourceObjectResponse | PartialDataSourceObjectResponse
+    ): DataSourceObjectResponse["title"] | undefined => {
+      return isFullDataSource(response) ? response.title : undefined
+    }
+
+    const getDatabaseTitle = (
+      response: DatabaseObjectResponse | PartialDatabaseObjectResponse
+    ): DatabaseObjectResponse["title"] | undefined => {
+      return isFullDatabase(response) ? response.title : undefined
+    }
+
+    it("distinguishes partial and full data sources", () => {
+      const partialDataSource: PartialDataSourceObjectResponse = {
+        object: "data_source",
+        id: "partial-data-source-id",
+        properties: {},
+      }
+      const fullDataSource = dataSource()
+
+      expect(isFullDataSource(partialDataSource)).toBe(false)
+      expect(isFullDataSource(fullDataSource)).toBe(true)
+      expect(getDataSourceTitle(partialDataSource)).toBeUndefined()
+      expect(getDataSourceTitle(fullDataSource)).toEqual([])
+    })
+
+    it("distinguishes partial and full databases", () => {
+      const partialDatabase: PartialDatabaseObjectResponse = {
+        object: "database",
+        id: "partial-database-id",
+      }
+      const fullDatabase = database()
+
+      expect(isFullDatabase(partialDatabase)).toBe(false)
+      expect(isFullDatabase(fullDatabase)).toBe(true)
+      expect(getDatabaseTitle(partialDatabase)).toBeUndefined()
+      expect(getDatabaseTitle(fullDatabase)).toEqual([])
+    })
+  })
+
   describe(iteratePaginatedAPI, () => {
     const mockPaginatedEndpoint = jest.fn<
       Promise<{
@@ -346,6 +435,7 @@ describe("Notion API helpers", () => {
       return {
         object: "data_source",
         id,
+        title: [],
         created_time: createdTime,
       }
     }


### PR DESCRIPTION
## Description

#### Problem

`isFullDataSource` and `isFullDatabase` checked only the resource `object` discriminator. Partial API responses use the same discriminator, so both helpers returned `true` and incorrectly narrowed partial objects to full response types.

#### Solution

Require the full-only `title` field in both structural guards, matching the approach already used by `isFullPage` and `isFullBlock`. Add regression coverage for partial and full data source/database shapes, including compile-time use of full-only fields after narrowing.

#### Result

Partial data source and database responses now return `false`, while full responses return `true`. The TypeScript build confirms the exported predicates still narrow to `DataSourceObjectResponse` and `DatabaseObjectResponse`.

#### Details

The existing wiki data-source query fixture now includes `title: []` because it represents a full child data-source row.

Closes BUG-324367.

[Code change explainer](https://app.dev.notion.com/p/3bbb35e6e67f8126b953f008195f01e3)

[Agent conversation](https://app.dev.notion.com/agent/32cb35e6e67f804c84820092ec038c49?wfv=activity&at=3bbb35e6e67f819e845900a9d52b8fe3)

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Validated with `npm run build`, the focused helper test suite, all 106 Jest tests, and `npm run lint` (Prettier, ESLint, and cspell).

## Screenshots

Not applicable; this change has no UI impact.
