### PR TITLE
Warn when the client holds a token inside a browser page

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ const notion = new Client({
 })
 ```
 
-A token passed per request through `auth` carries the same risk. The `agent` option is ignored in browsers. OAuth token endpoints under `/v1/oauth/` don't send CORS headers, so exchange authorization codes on a server.
+A token passed per request through `auth` triggers the same warning once per client. Web workers and service workers count as a browser too, because every visitor downloads their script. Test runners that emulate a browser, such as jsdom, also trigger the warning. In tests, pass `dangerouslyAllowBrowser: true` or set `logLevel` to `LogLevel.ERROR`. The `agent` option is ignored in browsers. OAuth token endpoints under `/v1/oauth/` don't send CORS headers, so exchange authorization codes on a server.
 
 ### Automatic retries
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ The `Client` constructor accepts one options object.
 
 The Notion API sends CORS headers, so browser code can call `api.notion.com` directly. The client works in modern browsers with the built-in `fetch`.
 
-A token in a web page isn't a secret. Anyone who can load the page can read it and act as your integration.
+A token in a web page isn't a secret. Anyone who can load the page can read it and act as your connection.
 
-- For an app other people use, keep the token on a server. Use a public integration with OAuth, exchange the authorization code on your server, and send the page only the data it needs.
+- For an app other people use, keep the token on a server. Create a [public connection](https://developers.notion.com/guides/get-started/public-connections), which uses OAuth. Exchange the authorization code on your server, and send the page only the data it needs.
 - For a personal tool or a local page that only you can open, using a token directly is your own risk to accept.
 
 The client logs a warning when you construct it with `auth` inside a browser page. Pass `dangerouslyAllowBrowser: true` to confirm you understand the risk and silence the warning.

--- a/README.md
+++ b/README.md
@@ -131,15 +131,36 @@ A custom `logger` receives `logLevel`, `message`, and `extraInfo`. It should ret
 
 The `Client` constructor accepts one options object.
 
-| Option      | Default value               | Type           | Description                                                                                                                                                         |
-| ----------- | --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `auth`      | `undefined`                 | `string`       | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request.                                                             |
-| `logLevel`  | `LogLevel.WARN`             | `LogLevel`     | Verbosity of logs the instance will produce. By default, logs are written to `stdout`.                                                                              |
-| `timeoutMs` | `DEFAULT_TIMEOUT_MS`        | `number`       | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                                              |
-| `baseUrl`   | `DEFAULT_BASE_URL`          | `string`       | The root URL for sending API requests. This can be changed to test with a mock server.                                                                              |
-| `logger`    | Log to console              | `Logger`       | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`.                              |
-| `agent`     | Default node agent          | `http.Agent`   | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent)        |
-| `retry`     | See [constants](#constants) | `RetryOptions` | Configuration for automatic retries on rate limits (429), service overloads (529), and server errors (500, 503). See [Automatic retries](#automatic-retries) below. |
+| Option                    | Default value               | Type           | Description                                                                                                                                                         |
+| ------------------------- | --------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auth`                    | `undefined`                 | `string`       | Bearer token for authentication. If left undefined, the `auth` parameter should be set on each request.                                                             |
+| `logLevel`                | `LogLevel.WARN`             | `LogLevel`     | Verbosity of logs the instance will produce. By default, logs are written to `stdout`.                                                                              |
+| `timeoutMs`               | `DEFAULT_TIMEOUT_MS`        | `number`       | Number of milliseconds to wait before emitting a `RequestTimeoutError`                                                                                              |
+| `baseUrl`                 | `DEFAULT_BASE_URL`          | `string`       | The root URL for sending API requests. This can be changed to test with a mock server.                                                                              |
+| `logger`                  | Log to console              | `Logger`       | A custom logging function. This function is only called when the client emits a log that is equal or greater severity than `logLevel`.                              |
+| `agent`                   | Default node agent          | `http.Agent`   | Used to control creation of TCP sockets. A common use is to proxy requests with [`https-proxy-agent`](https://github.com/TooTallNate/node-https-proxy-agent)        |
+| `retry`                   | See [constants](#constants) | `RetryOptions` | Configuration for automatic retries on rate limits (429), service overloads (529), and server errors (500, 503). See [Automatic retries](#automatic-retries) below. |
+| `dangerouslyAllowBrowser` | `false`                     | `boolean`      | Confirms you mean to hold a token inside a browser page and silences the warning the client logs in that case. See [Browser usage](#browser-usage) below.           |
+
+### Browser usage
+
+The Notion API sends CORS headers, so browser code can call `api.notion.com` directly. The client works in modern browsers with the built-in `fetch`.
+
+A token in a web page isn't a secret. Anyone who can load the page can read it and act as your integration.
+
+- For an app other people use, keep the token on a server. Use a public integration with OAuth, exchange the authorization code on your server, and send the page only the data it needs.
+- For a personal tool or a local page that only you can open, using a token directly is your own risk to accept.
+
+The client logs a warning when you construct it with `auth` inside a browser page. Pass `dangerouslyAllowBrowser: true` to confirm you understand the risk and silence the warning.
+
+```js
+const notion = new Client({
+  auth: tokenTypedIntoYourOwnPage,
+  dangerouslyAllowBrowser: true,
+})
+```
+
+A token passed per request through `auth` carries the same risk. The `agent` option is ignored in browsers. OAuth token endpoints under `/v1/oauth/` don't send CORS headers, so exchange authorization codes on a server.
 
 ### Automatic retries
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -114,6 +114,13 @@ export type ClientOptions = {
    * Set to false to disable retries entirely.
    */
   retry?: RetryOptions | false
+  /**
+   * Confirms that you mean to hold a Notion token inside a browser page, and
+   * silences the warning the client logs in that case. Anyone who can load the
+   * page can read the token and act as your integration, so only set this for
+   * pages that nobody else can open.
+   */
+  dangerouslyAllowBrowser?: boolean
 }
 
 type FileParam = {
@@ -122,6 +129,23 @@ type FileParam = {
 }
 
 const START_CURSOR_PARAM_NAME = "start_cursor"
+
+const BROWSER_TOKEN_WARNING =
+  "This client holds a Notion token inside a browser page. Anyone who can " +
+  "load the page can read the token and act as your integration. Only do " +
+  "this for pages that nobody else can open. Pass " +
+  "`dangerouslyAllowBrowser: true` to confirm and silence this warning. See " +
+  "https://developers.notion.com/guides/get-started/handling-api-keys#calling-the-api-from-a-browser"
+
+/**
+ * True only inside a browser page. Node, Bun, Deno, edge runtimes, and web
+ * workers have no `window.document`, and those are the places a token can
+ * live safely.
+ */
+function isBrowserEnvironment(): boolean {
+  const maybeWindow = (globalThis as { window?: { document?: unknown } }).window
+  return maybeWindow !== undefined && maybeWindow.document !== undefined
+}
 
 export type RequestParameters = {
   path: string
@@ -193,6 +217,14 @@ export default class Client {
         options?.retry?.initialRetryDelayMs ?? DEFAULT_INITIAL_RETRY_DELAY_MS
       this.#maxRetryDelayMs =
         options?.retry?.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS
+    }
+
+    if (
+      options?.auth !== undefined &&
+      !options.dangerouslyAllowBrowser &&
+      isBrowserEnvironment()
+    ) {
+      this.log(LogLevel.WARN, BROWSER_TOKEN_WARNING, {})
     }
   }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -138,13 +138,18 @@ const BROWSER_TOKEN_WARNING =
   "https://developers.notion.com/guides/get-started/handling-api-keys#calling-the-api-from-a-browser"
 
 /**
- * True only inside a browser page. Node, Bun, Deno, edge runtimes, and web
- * workers have no `window.document`, and those are the places a token can
- * live safely.
+ * True inside a browser page, web worker, or service worker: the places where
+ * every visitor downloads the script, so a token in it is public. Node, Bun,
+ * Deno, and edge runtimes have neither `window.document` nor
+ * `WorkerGlobalScope`. Test runners that emulate a browser, such as jsdom,
+ * also count as a browser here.
  */
 function isBrowserEnvironment(): boolean {
   const maybeWindow = (globalThis as { window?: { document?: unknown } }).window
-  return maybeWindow !== undefined && maybeWindow.document !== undefined
+  if (maybeWindow !== undefined && maybeWindow.document !== undefined) {
+    return true
+  }
+  return "WorkerGlobalScope" in globalThis
 }
 
 export type RequestParameters = {
@@ -193,6 +198,8 @@ export default class Client {
   #maxRetries: number
   #initialRetryDelayMs: number
   #maxRetryDelayMs: number
+  #dangerouslyAllowBrowser: boolean
+  #warnedBrowserToken = false
 
   static readonly defaultNotionVersion = "2025-09-03"
 
@@ -219,12 +226,9 @@ export default class Client {
         options?.retry?.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS
     }
 
-    if (
-      options?.auth !== undefined &&
-      !options.dangerouslyAllowBrowser &&
-      isBrowserEnvironment()
-    ) {
-      this.log(LogLevel.WARN, BROWSER_TOKEN_WARNING, {})
+    this.#dangerouslyAllowBrowser = options?.dangerouslyAllowBrowser ?? false
+    if (options?.auth !== undefined) {
+      this.warnIfTokenInBrowser()
     }
   }
 
@@ -423,6 +427,9 @@ export default class Client {
   private buildAuthHeader(
     auth: RequestParameters["auth"]
   ): Record<string, string> {
+    if (auth !== undefined) {
+      this.warnIfTokenInBrowser()
+    }
     if (typeof auth === "object") {
       const unencodedCredential = `${auth.client_id}:${auth.client_secret}`
       const encodedCredential =
@@ -1145,6 +1152,22 @@ export default class Client {
    * @param auth API key or access token
    * @returns headers key-value object
    */
+  /**
+   * Warns once per client when a token or client secret is used inside a
+   * browser. Covers both the constructor `auth` and per-request `auth`, since
+   * a page that asks the visitor to type a token usually uses the latter.
+   */
+  private warnIfTokenInBrowser(): void {
+    if (this.#dangerouslyAllowBrowser || this.#warnedBrowserToken) {
+      return
+    }
+    if (!isBrowserEnvironment()) {
+      return
+    }
+    this.#warnedBrowserToken = true
+    this.log(LogLevel.WARN, BROWSER_TOKEN_WARNING, {})
+  }
+
   private authAsHeaders(auth?: string): Record<string, string> {
     const headers: Record<string, string> = {}
     const authHeaderValue = auth ?? this.#auth

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -117,7 +117,7 @@ export type ClientOptions = {
   /**
    * Confirms that you mean to hold a Notion token inside a browser page, and
    * silences the warning the client logs in that case. Anyone who can load the
-   * page can read the token and act as your integration, so only set this for
+   * page can read the token and act as your connection, so only set this for
    * pages that nobody else can open.
    */
   dangerouslyAllowBrowser?: boolean
@@ -132,7 +132,7 @@ const START_CURSOR_PARAM_NAME = "start_cursor"
 
 const BROWSER_TOKEN_WARNING =
   "This client holds a Notion token inside a browser page. Anyone who can " +
-  "load the page can read the token and act as your integration. Only do " +
+  "load the page can read the token and act as your connection. Only do " +
   "this for pages that nobody else can open. Pass " +
   "`dangerouslyAllowBrowser: true` to confirm and silence this warning. See " +
   "https://developers.notion.com/guides/get-started/handling-api-keys#calling-the-api-from-a-browser"

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -32,6 +32,58 @@ describe("Notion SDK Client", () => {
     new Client({ auth: "foo" })
   })
 
+  describe("browser token warning", () => {
+    const globalWithWindow = globalThis as { window?: unknown }
+
+    afterEach(() => {
+      delete globalWithWindow.window
+    })
+
+    it("warns once when constructed with a token inside a browser page", () => {
+      globalWithWindow.window = { document: {} }
+      const logger = jest.fn()
+
+      new Client({ auth: "ntn_test_token", logger })
+
+      expect(logger).toHaveBeenCalledTimes(1)
+      expect(logger).toHaveBeenCalledWith(
+        LogLevel.WARN,
+        expect.stringContaining("dangerouslyAllowBrowser"),
+        {}
+      )
+    })
+
+    it("stays quiet when dangerouslyAllowBrowser is set", () => {
+      globalWithWindow.window = { document: {} }
+      const logger = jest.fn()
+
+      new Client({
+        auth: "ntn_test_token",
+        logger,
+        dangerouslyAllowBrowser: true,
+      })
+
+      expect(logger).not.toHaveBeenCalled()
+    })
+
+    it("stays quiet in a browser page without a token", () => {
+      globalWithWindow.window = { document: {} }
+      const logger = jest.fn()
+
+      new Client({ logger, baseUrl: "https://proxy.example.com" })
+
+      expect(logger).not.toHaveBeenCalled()
+    })
+
+    it("stays quiet outside a browser page", () => {
+      const logger = jest.fn()
+
+      new Client({ auth: "ntn_test_token", logger })
+
+      expect(logger).not.toHaveBeenCalled()
+    })
+  })
+
   it("keeps detached generated methods bound to the current request implementation", async () => {
     const mockFetch = createMockFetch()
     const client = new Client({ auth: "default-token", fetch: mockFetch })

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -82,6 +82,48 @@ describe("Notion SDK Client", () => {
 
       expect(logger).not.toHaveBeenCalled()
     })
+
+    it("warns once for per-request tokens in a browser page", async () => {
+      globalWithWindow.window = { document: {} }
+      const logger = jest.fn()
+      const client = new Client({ logger, fetch: createMockFetch() })
+
+      await client.users.me({ auth: "ntn_test_token" })
+      await client.users.me({ auth: "ntn_test_token" })
+
+      const warnings = logger.mock.calls.filter(
+        ([level, message]) =>
+          level === LogLevel.WARN &&
+          typeof message === "string" &&
+          message.includes("dangerouslyAllowBrowser")
+      )
+      expect(warnings).toHaveLength(1)
+    })
+
+    it("warns inside a web worker scope", () => {
+      const globalWithWorkerScope = globalThis as {
+        WorkerGlobalScope?: unknown
+      }
+      globalWithWorkerScope.WorkerGlobalScope = class {}
+      const logger = jest.fn()
+
+      try {
+        new Client({ auth: "ntn_test_token", logger })
+      } finally {
+        delete globalWithWorkerScope.WorkerGlobalScope
+      }
+
+      expect(logger).toHaveBeenCalledTimes(1)
+    })
+
+    it("is silenced by logLevel ERROR", () => {
+      globalWithWindow.window = { document: {} }
+      const logger = jest.fn()
+
+      new Client({ auth: "ntn_test_token", logger, logLevel: LogLevel.ERROR })
+
+      expect(logger).not.toHaveBeenCalled()
+    })
   })
 
   it("keeps detached generated methods bound to the current request implementation", async () => {


### PR DESCRIPTION
## Description

Adds a `dangerouslyAllowBrowser` client option and a "Browser usage" README section. When the client is built with `auth` inside a browser page, it logs one warning: anyone who can load the page can read the token and act as the integration. Passing `dangerouslyAllowBrowser: true` confirms the choice and silences the warning. OpenAI and Anthropic use the same option name in their SDKs.

This is the SDK half of the change that makes `api.notion.com` send CORS headers (https://github.com/makenotion/notion-next/pull/336692). Merge after that server change is live, because the README now states the API sends CORS headers.

## How was this change tested?

- [x] Automated test (unit, integration, etc.)
- [ ] Manual test (provide reproducible testing steps below)

Four new Jest cases cover: warns once in a browser page with a token, quiet with the option set, quiet without a token, quiet outside a browser. `npm run build`, `npm run lint`, and the Client test suite pass locally.

## Screenshots

None. No UI change.