### PR TITLE
fix(types): correct property item response types for title and rich text

### DIFF
--- a/src/api-endpoints/pages.ts
+++ b/src/api-endpoints/pages.ts
@@ -253,7 +253,7 @@ export type RelationPropertyItemObjectResponse = {
 
 export type RichTextPropertyItemObjectResponse = {
   type: "rich_text"
-  rich_text: RichTextItemResponse
+  rich_text: Array<RichTextItemResponse>
   object: "property_item"
   id: string
 }
@@ -292,7 +292,7 @@ type StringFormulaPropertyResponse = { type: "string"; string: string | null }
 
 export type TitlePropertyItemObjectResponse = {
   type: "title"
-  title: RichTextItemResponse
+  title: Array<RichTextItemResponse>
   object: "property_item"
   id: string
 }

--- a/test/property-item-response-types.test.ts
+++ b/test/property-item-response-types.test.ts
@@ -1,0 +1,11 @@
+import type {
+  RichTextPropertyItemObjectResponse,
+  TitlePropertyItemObjectResponse,
+} from "../src"
+
+const richText = {} as RichTextPropertyItemObjectResponse
+const title = {} as TitlePropertyItemObjectResponse
+
+// These should compile because both properties are arrays.
+richText.rich_text[0]!.plain_text
+title.title[0]!.plain_text


### PR DESCRIPTION
## Description

Fixes #653.

`TitlePropertyItemObjectResponse.title` and `RichTextPropertyItemObjectResponse.rich_text` were typed as single `RichTextItemResponse` values, but data source query responses expose them as arrays.

This updates both definitions to `Array<RichTextItemResponse>` and adds a regression type test to ensure indexed access (for example, `rich_text[0]!.plain_text`) continues to type-check correctly.

## How was this change tested?

* [x] Automated test (unit, integration, etc.)
* [x] Manual test (provide reproducible testing steps below)

**Manual validation**

1. Updated the `TitlePropertyItemObjectResponse` and `RichTextPropertyItemObjectResponse` type definitions.
2. Added a regression type test covering indexed access for both response types.
3. Ran `npx tsc --noEmit` to verify the project compiles with the updated types.

## Screenshots

 Added a regression type test and verified the updated types compile successfully with npx tsc --noEmit.

<img width="1307" height="697" alt="image" src="https://github.com/user-attachments/assets/aaf8ffcc-4fdd-407d-93f5-b646e56389be" />