### PR TITLE
Fix/654 generic formula property types

### DIFF
--- a/src/api-endpoints/pages.ts
+++ b/src/api-endpoints/pages.ts
@@ -87,19 +87,23 @@ export type FilesPropertyItemObjectResponse = {
   id: string
 }
 
-export type FormulaPropertyItemObjectResponse = {
+type FormulaValue = string | DateResponse | number | boolean
+
+type FormulaPropertyResponse<T extends FormulaValue = FormulaValue> =
+  | (T extends string ? StringFormulaPropertyResponse : never)
+  | (T extends DateResponse ? DateFormulaPropertyResponse : never)
+  | (T extends number ? NumberFormulaPropertyResponse : never)
+  | (T extends boolean ? BooleanFormulaPropertyResponse : never)
+  | UnsupportedFormulaPropertyResponse
+
+export type FormulaPropertyItemObjectResponse<
+  T extends FormulaValue = FormulaValue,
+> = {
   type: "formula"
-  formula: FormulaPropertyResponse
+  formula: FormulaPropertyResponse<T>
   object: "property_item"
   id: string
 }
-
-type FormulaPropertyResponse =
-  | StringFormulaPropertyResponse
-  | DateFormulaPropertyResponse
-  | NumberFormulaPropertyResponse
-  | BooleanFormulaPropertyResponse
-  | UnsupportedFormulaPropertyResponse
 
 export type LastEditedByPropertyItemObjectResponse = {
   type: "last_edited_by"

--- a/test/formula-property-types.test.ts
+++ b/test/formula-property-types.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@jest/globals"
+import type { DateResponse } from "../src/api-endpoints/common"
+import type { FormulaPropertyItemObjectResponse } from "../src/api-endpoints/pages"
+
+describe("FormulaPropertyItemObjectResponse", () => {
+  it("supports narrowing formula values by type", () => {
+    const stringProperty: FormulaPropertyItemObjectResponse<string> = {
+      type: "formula",
+      formula: {
+        type: "string",
+        string: "example",
+      },
+      object: "property_item",
+      id: "test-id",
+    }
+
+    const numberProperty: FormulaPropertyItemObjectResponse<number> = {
+      type: "formula",
+      formula: {
+        type: "number",
+        number: 42,
+      },
+      object: "property_item",
+      id: "test-id",
+    }
+
+    const dateProperty: FormulaPropertyItemObjectResponse<DateResponse> = {
+      type: "formula",
+      formula: {
+        type: "date",
+        date: null,
+      },
+      object: "property_item",
+      id: "test-id",
+    }
+
+    const booleanProperty: FormulaPropertyItemObjectResponse<boolean> = {
+      type: "formula",
+      formula: {
+        type: "boolean",
+        boolean: true,
+      },
+      object: "property_item",
+      id: "test-id",
+    }
+
+    expect(stringProperty.formula.type).toBe("string")
+    expect(numberProperty.formula.type).toBe("number")
+    expect(dateProperty.formula.type).toBe("date")
+    expect(booleanProperty.formula.type).toBe("boolean")
+  })
+
+  it("rejects formula values that do not match the generic type", () => {
+    const invalidProperty: FormulaPropertyItemObjectResponse<number> = {
+      type: "formula",
+      formula: {
+        // @ts-expect-error A string formula must not be assignable to a number response.
+        type: "string",
+        string: "example",
+      },
+      object: "property_item",
+      id: "test-id",
+    }
+
+    expect(invalidProperty).toBeDefined()
+  })
+})


### PR DESCRIPTION
# Description

Fixes: #654

Add generic type support to `FormulaPropertyItemObjectResponse` so consumers can narrow formula property responses to the expected value type.

The existing default behavior is preserved, including support for unsupported formula types, so this change does not introduce a breaking change.

## How was this change tested?

* [x] Automated test (unit, integration, etc.)
* [ ] Manual test (provide reproducible testing steps below)

TypeScript compilation was verified with:

```bash
npx tsc --noEmit
```

A dedicated type test was added to verify that string, number, date, and boolean formula responses can be narrowed using the generic type parameter, and that mismatched formula types are rejected by TypeScript.

## Screenshots

N/A 

